### PR TITLE
parser, analyzer, codegen: functions with arguments.

### DIFF
--- a/analyzer/binary_expression.cpp
+++ b/analyzer/binary_expression.cpp
@@ -80,13 +80,10 @@ reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyz
         ).then([&](auto && simplified) {
             replace_uptr(_lhs, get<0>(simplified), ctx);
             replace_uptr(_rhs, get<1>(simplified), ctx);
-            return _overload->simplify(ctx);
-        }).then([&]() {
             return _overload->simplify(ctx, { _lhs->get_variable(), _rhs->get_variable() });
         }).then([&](auto && simplified) -> expression * {
             if (simplified)
             {
-                ctx.something_happened();
                 return simplified;
             }
 

--- a/analyzer/binary_expression.cpp
+++ b/analyzer/binary_expression.cpp
@@ -62,6 +62,16 @@ reaver::future<> reaver::vapor::analyzer::_v1::binary_expression::_analyze()
         });
 }
 
+std::unique_ptr<reaver::vapor::analyzer::_v1::expression> reaver::vapor::analyzer::_v1::binary_expression::_clone_expr_with_replacement(reaver::vapor::analyzer::_v1::replacements & repl) const
+{
+    auto ret = std::unique_ptr<binary_expression>(new binary_expression(*this));
+
+    ret->_lhs = _lhs->clone_expr_with_replacement(repl);
+    ret->_rhs = _rhs->clone_expr_with_replacement(repl);
+
+    return ret;
+}
+
 reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyzer::_v1::binary_expression::_simplify_expr(reaver::vapor::analyzer::_v1::optimization_context & ctx)
 {
     return when_all(

--- a/analyzer/block.cpp
+++ b/analyzer/block.cpp
@@ -107,6 +107,16 @@ reaver::future<> reaver::vapor::analyzer::_v1::block::_analyze()
     return fut;
 }
 
+std::unique_ptr<reaver::vapor::analyzer::_v1::statement> reaver::vapor::analyzer::_v1::block::_clone_with_replacement(reaver::vapor::analyzer::_v1::replacements & repl) const
+{
+    auto ret = std::unique_ptr<block>(new block(*this));
+
+    ret->_statements = fmap(_statements, [&](auto && stmt){ return stmt->clone_with_replacement(repl); });
+    ret->_value_expr = fmap(_value_expr, [&](auto && expr){ return expr->clone_expr_with_replacement(repl); });
+
+    return ret;
+}
+
 reaver::future<reaver::vapor::analyzer::_v1::statement *> reaver::vapor::analyzer::_v1::block::_simplify(reaver::vapor::analyzer::_v1::optimization_context & ctx)
 {
     auto fut = when_all(

--- a/analyzer/block.cpp
+++ b/analyzer/block.cpp
@@ -154,7 +154,7 @@ std::vector<reaver::vapor::codegen::_v1::ir::instruction> reaver::vapor::analyze
             std::back_inserter(scope_cleanup),
             [&ctx](auto && symbol) {
                 auto variable_ir = symbol->get_variable()->codegen_ir(ctx);
-                auto variable = get<codegen::ir::value>(variable_ir.back());
+                auto variable = get<codegen::ir::value>(variable_ir);
                 return codegen::ir::instruction{
                     {}, {},
                     { boost::typeindex::type_id<codegen::ir::destruction_instruction>() },

--- a/analyzer/boolean.cpp
+++ b/analyzer/boolean.cpp
@@ -25,9 +25,9 @@
 #include "vapor/codegen/ir/variable.h"
 #include "vapor/codegen/ir/type.h"
 
-std::shared_ptr<reaver::vapor::codegen::_v1::ir::variable_type> reaver::vapor::analyzer::_v1::boolean_type::_codegen_type(reaver::vapor::analyzer::_v1::ir_generation_context &) const
+void reaver::vapor::analyzer::_v1::boolean_type::_codegen_type(reaver::vapor::analyzer::_v1::ir_generation_context &) const
 {
-    return codegen::ir::builtin_types().boolean;
+    _codegen_t = codegen::ir::builtin_types().boolean;
 }
 
 reaver::vapor::analyzer::_v1::variable_ir reaver::vapor::analyzer::_v1::boolean_constant::_codegen_ir(reaver::vapor::analyzer::_v1::ir_generation_context &) const
@@ -94,6 +94,7 @@ auto reaver::vapor::analyzer::_v1::boolean_type::_generate_function(const char32
             };
         }
     );
+    fun->set_name(name);
     fun->set_eval(eval);
     return fun;
 }

--- a/analyzer/boolean.cpp
+++ b/analyzer/boolean.cpp
@@ -47,6 +47,11 @@ reaver::vapor::analyzer::_v1::statement_ir reaver::vapor::analyzer::_v1::boolean
     } };
 }
 
+std::unique_ptr<reaver::vapor::analyzer::_v1::type> reaver::vapor::analyzer::_v1::make_boolean_type()
+{
+    return std::make_unique<boolean_type>();
+}
+
 template<typename Instruction, typename Eval>
 auto reaver::vapor::analyzer::_v1::boolean_type::_generate_function(const char32_t * name, const char * desc, Eval eval, reaver::vapor::analyzer::_v1::type * return_type)
 {

--- a/analyzer/boolean.cpp
+++ b/analyzer/boolean.cpp
@@ -55,17 +55,19 @@ std::unique_ptr<reaver::vapor::analyzer::_v1::type> reaver::vapor::analyzer::_v1
 template<typename Instruction, typename Eval>
 auto reaver::vapor::analyzer::_v1::boolean_type::_generate_function(const char32_t * name, const char * desc, Eval eval, reaver::vapor::analyzer::_v1::type * return_type)
 {
+    auto lhs = make_blank_variable(builtin_types().boolean.get());
+    auto rhs = make_blank_variable(builtin_types().boolean.get());
+
+    auto lhs_arg = lhs.get();
+    auto rhs_arg = rhs.get();
+
     auto fun = make_function(
         desc,
         return_type,
-        { builtin_types().boolean.get(), builtin_types().boolean.get() },
-        [name, return_type](ir_generation_context & ctx) {
-            auto lhs = codegen::ir::make_variable(
-                builtin_types().boolean->codegen_type(ctx)
-            );
-            auto rhs = codegen::ir::make_variable(
-                builtin_types().boolean->codegen_type(ctx)
-            );
+        { lhs_arg, rhs_arg },
+        [name, return_type, lhs = std::move(lhs), rhs = std::move(rhs)](ir_generation_context & ctx) {
+            auto lhs_ir = get_ir_variable(lhs->codegen_ir(ctx));
+            auto rhs_ir = get_ir_variable(rhs->codegen_ir(ctx));
 
             auto retval = codegen::ir::make_variable(
                 return_type->codegen_type(ctx)
@@ -73,13 +75,13 @@ auto reaver::vapor::analyzer::_v1::boolean_type::_generate_function(const char32
 
             return codegen::ir::function{
                 name,
-                {}, { lhs, rhs },
+                {}, { lhs_ir, rhs_ir },
                 retval,
                 {
                     codegen::ir::instruction{
                         none, none,
                         { boost::typeindex::type_id<Instruction>() },
-                        { lhs, rhs },
+                        { lhs_ir, rhs_ir },
                         retval
                     },
                     codegen::ir::instruction{

--- a/analyzer/closure.cpp
+++ b/analyzer/closure.cpp
@@ -100,6 +100,11 @@ reaver::future<> reaver::vapor::analyzer::_v1::closure::_analyze()
     });
 }
 
+std::unique_ptr<reaver::vapor::analyzer::_v1::expression> reaver::vapor::analyzer::_v1::closure::_clone_expr_with_replacement(reaver::vapor::analyzer::_v1::replacements & repl) const
+{
+    assert(!"this shouldn't be called, or, when called, should return an empty expression...");
+}
+
 reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyzer::_v1::closure::_simplify_expr(reaver::vapor::analyzer::_v1::optimization_context & ctx)
 {
     return _body->simplify(ctx)

--- a/analyzer/closure.cpp
+++ b/analyzer/closure.cpp
@@ -25,21 +25,28 @@
 #include "vapor/analyzer/symbol.h"
 #include "vapor/codegen/ir/type.h"
 
-std::shared_ptr<reaver::vapor::codegen::_v1::ir::variable_type> reaver::vapor::analyzer::_v1::closure_type::_codegen_type(reaver::vapor::analyzer::_v1::ir_generation_context & ctx) const
+void reaver::vapor::analyzer::_v1::closure_type::_codegen_type(reaver::vapor::analyzer::_v1::ir_generation_context & ctx) const
 {
-    auto type = codegen::ir::make_type(U"__closure_" + boost::locale::conv::utf_to_utf<char32_t>(std::to_string(ctx.closure_index++)), get_scope()->codegen_ir(ctx), 0, {});
+    auto actual_type = *_codegen_t;
+
+    auto type = codegen::ir::variable_type{
+        U"__closure_" + boost::locale::conv::utf_to_utf<char32_t>(std::to_string(ctx.closure_index++)),
+        get_scope()->codegen_ir(ctx),
+        0,
+        {}
+    };
 
     auto scopes = get_scope()->codegen_ir(ctx);
-    scopes.emplace_back(type->name, codegen::ir::scope_type::type);
+    scopes.emplace_back(type.name, codegen::ir::scope_type::type);
 
     auto fn = _function->codegen_ir(ctx);
     fn.scopes = scopes;
-    fn.parent_type = type;
-    type->members = { codegen::ir::member{ fn } };
+    fn.parent_type = actual_type;
+    type.members = { codegen::ir::member{ fn } };
 
     ctx.add_generated_function(_function.get());
 
-    return type;
+    *actual_type = std::move(type);
 }
 
 void reaver::vapor::analyzer::_v1::closure::print(std::ostream & os, std::size_t indent) const
@@ -59,9 +66,26 @@ void reaver::vapor::analyzer::_v1::closure::print(std::ostream & os, std::size_t
 
 reaver::future<> reaver::vapor::analyzer::_v1::closure::_analyze()
 {
-    return when_all(fmap(_argument_list, [&](auto && arg) {
-        return arg.type_expression->analyze();
-    })).then([&]{
+    auto initial_future = [&]{
+        if (_return_type)
+        {
+            return (*_return_type)->analyze()
+                .then([&]{
+                    auto var = (*_return_type)->get_variable();
+
+                    assert(var->get_type() == builtin_types().type.get());
+                    assert(var->is_constant());
+                });
+        }
+
+        return make_ready_future();
+    }();
+
+    return initial_future.then([&]{
+        return when_all(fmap(_argument_list, [&](auto && arg) {
+            return arg.type_expression->analyze();
+        }));
+    }).then([&]{
         fmap(_argument_list, [&](auto && arg) {
             arg.variable->set_type(arg.type_expression->get_variable());
             return unit{};
@@ -69,6 +93,15 @@ reaver::future<> reaver::vapor::analyzer::_v1::closure::_analyze()
 
         return _body->analyze();
     }).then([&] {
+        fmap(_return_type, [&](auto && ret_type) {
+            auto explicit_type = ret_type->get_variable();
+            auto type_var = dynamic_cast<type_variable *>(explicit_type);
+
+            assert(type_var->get_value() == _body->return_type());
+
+            return unit{};
+        });
+
         auto arg_variables = fmap(_argument_list, [&](auto && arg) -> variable * {
             return arg.variable.get();
         });
@@ -93,6 +126,7 @@ reaver::future<> reaver::vapor::analyzer::_v1::closure::_analyze()
             _parse.range
         );
 
+        function->set_name(U"operator()");
         function->set_body(_body.get());
 
         _type = std::make_unique<closure_type>(_scope.get(), this, std::move(function));

--- a/analyzer/closure.cpp
+++ b/analyzer/closure.cpp
@@ -69,17 +69,14 @@ reaver::future<> reaver::vapor::analyzer::_v1::closure::_analyze()
 
         return _body->analyze();
     }).then([&] {
-        auto arg_types = fmap(_argument_list, [&](auto && arg) {
-            // TODO: this must be done somewhat differently
-            auto type_var = dynamic_cast<type_variable *>(arg.type_expression->get_variable());
-            assert(type_var);
-            return type_var->get_value();
+        auto arg_variables = fmap(_argument_list, [&](auto && arg) -> variable * {
+            return arg.variable.get();
         });
 
         auto function = make_function(
             "closure",
             _body->return_type(),
-            std::move(arg_types),
+            std::move(arg_variables),
             [this](ir_generation_context & ctx) {
                 return codegen::ir::function{
                     U"operator()",

--- a/analyzer/expression.cpp
+++ b/analyzer/expression.cpp
@@ -142,3 +142,13 @@ void reaver::vapor::analyzer::_v1::variable_ref_expression::print(std::ostream &
     os << in << "type: " << get_variable()->get_type()->explain() << '\n';
 }
 
+std::unique_ptr<reaver::vapor::analyzer::_v1::expression> reaver::vapor::analyzer::expression_list::_clone_expr_with_replacement(reaver::vapor::analyzer::_v1::replacements & repl) const
+{
+    auto ret = std::make_unique<expression_list>();
+    ret->range = range;
+
+    ret->value = fmap(value, [&](auto && expr) { return expr->clone_expr_with_replacement(repl); });
+
+    return ret;
+}
+

--- a/analyzer/expression.cpp
+++ b/analyzer/expression.cpp
@@ -84,8 +84,7 @@ std::unique_ptr<reaver::vapor::analyzer::_v1::expression> reaver::vapor::analyze
 
 reaver::future<> reaver::vapor::analyzer::_v1::expression_list::_analyze()
 {
-    return when_all(fmap(value, [&](auto && expr) { return expr->analyze(); }))
-        .then([&]{ _set_variable(make_expression_variable(this, value.back()->get_variable()->get_type())); });
+    return when_all(fmap(value, [&](auto && expr) { return expr->analyze(); }));
 }
 
 reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyzer::_v1::expression_list::_simplify_expr(reaver::vapor::analyzer::_v1::optimization_context & ctx)

--- a/analyzer/function.cpp
+++ b/analyzer/function.cpp
@@ -50,7 +50,7 @@ reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyz
                 assert(_body);
 
                 return [&]{
-                    if (args.size() && std::all_of(args.begin(), args.end(), [](auto && arg){ return arg->is_constant(); }))
+                    if (args.size())
                     {
                         auto body = _body->clone_with_replacement(
                             _arguments,

--- a/analyzer/function.cpp
+++ b/analyzer/function.cpp
@@ -44,7 +44,7 @@ reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyz
 {
     if (_body)
     {
-        if (!std::all_of(args.begin(), args.end(), [](auto && arg){ return arg->is_constant(); }))
+        if (!std::any_of(args.begin(), args.end(), [](auto && arg){ return arg->is_constant(); }))
         {
             return make_ready_future<expression *>(nullptr);
         }

--- a/analyzer/function.cpp
+++ b/analyzer/function.cpp
@@ -49,24 +49,57 @@ reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyz
                 _body = dynamic_cast<block *>(simplified);
                 assert(_body);
 
-                auto returns = _body->get_returns();
+                return [&]{
+                    if (args.size() && std::all_of(args.begin(), args.end(), [](auto && arg){ return arg->is_constant(); }))
+                    {
+                        auto body = _body->clone_with_replacement(
+                            _arguments,
+                            args
+                        );
 
-                assert(_body->has_return_expression() || returns.size());
-                auto var = _body->has_return_expression() ? _body->get_return_expression()->get_variable() : returns.front()->get_returned_variable();
-                auto begin = _body->has_return_expression() ? returns.begin() : returns.begin() + 1;
+                        auto simplify = [ctx = std::make_shared<optimization_context>()](auto self, auto body)
+                        {
+                            return body->simplify(*ctx)
+                                .then([&, old_body = body, ctx, self](auto && body) -> future<block *> {
+                                    if (!ctx->did_something_happen())
+                                    {
+                                        return make_ready_future<block *>(dynamic_cast<block *>(body));
+                                    }
 
-                if (!var->is_constant())
-                {
+                                    // ugh
+                                    // but I don't know how else to write this
+                                    // without creating a long overload for optctx
+                                    ctx->~optimization_context();
+                                    new (&*ctx) optimization_context();
+                                    return self(self, body);
+                                });
+                        };
+
+                        // this is a leak
+                        return simplify(simplify, body.release());
+                    }
+
+                    return make_ready_future(_body);
+                }().then([&](auto && body) {
+                    auto returns = body->get_returns();
+
+                    assert(body->has_return_expression() || returns.size());
+                    auto var = body->has_return_expression() ? body->get_return_expression()->get_variable() : returns.front()->get_returned_variable();
+                    auto begin = body->has_return_expression() ? returns.begin() : returns.begin() + 1;
+
+                    if (!var->is_constant())
+                    {
+                        return make_ready_future<expression *>(nullptr);
+                    }
+
+                    if (std::all_of(begin, returns.end(), [](auto && ret) { return ret->get_returned_variable()->is_constant(); })
+                        && std::all_of(begin, returns.end(), [&](auto && ret) { return ret->get_returned_variable()->is_equal(var); }))
+                    {
+                        return make_ready_future(make_variable_ref_expression(var).release());
+                    }
+
                     return make_ready_future<expression *>(nullptr);
-                }
-
-                if (std::all_of(begin, returns.end(), [](auto && ret) { return ret->get_returned_variable()->is_constant(); })
-                    && std::all_of(begin, returns.end(), [&](auto && ret) { return ret->get_returned_variable()->is_equal(var); }))
-                {
-                    return make_ready_future(make_variable_ref_expression(var).release());
-                }
-
-                return make_ready_future<expression *>(nullptr);
+                });
             });
     }
 

--- a/analyzer/id_expression.cpp
+++ b/analyzer/id_expression.cpp
@@ -67,7 +67,6 @@ reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyz
             if (simplified && simplified != _referenced)
             {
                 _referenced = simplified;
-                ctx.something_happened();
             }
             return this;
         });

--- a/analyzer/id_expression.cpp
+++ b/analyzer/id_expression.cpp
@@ -51,7 +51,7 @@ reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyz
 {
     return _referenced->simplify(ctx)
         .then([&](auto && simplified) -> expression * {
-            if (simplified)
+            if (simplified && simplified != _referenced)
             {
                 _referenced = simplified;
                 ctx.something_happened();

--- a/analyzer/id_expression.cpp
+++ b/analyzer/id_expression.cpp
@@ -32,7 +32,8 @@ void reaver::vapor::analyzer::_v1::id_expression::print(std::ostream & os, std::
 
 reaver::future<> reaver::vapor::analyzer::_v1::id_expression::_analyze()
 {
-    return std::accumulate(_parse.id_expression_value.begin() + 1, _parse.id_expression_value.end(), _lex_scope->resolve(_parse.id_expression_value.front().string),
+    return std::accumulate(_parse.id_expression_value.begin() + 1, _parse.id_expression_value.end(),
+        _lex_scope->resolve(_parse.id_expression_value.front().string),
         [&](auto fut, auto && ident) {
             return fut.then([&ident](auto && symbol) {
                 return symbol->get_variable_future();

--- a/analyzer/id_expression.cpp
+++ b/analyzer/id_expression.cpp
@@ -66,7 +66,7 @@ reaver::vapor::analyzer::_v1::statement_ir reaver::vapor::analyzer::_v1::id_expr
         none, none,
         { boost::typeindex::type_id<codegen::ir::pass_value_instruction>() },
         {},
-        { get<codegen::ir::value>(_referenced->codegen_ir(ctx).back()) }
+        { get<codegen::ir::value>(_referenced->codegen_ir(ctx)) }
     } };
 }
 

--- a/analyzer/id_expression.cpp
+++ b/analyzer/id_expression.cpp
@@ -47,6 +47,19 @@ reaver::future<> reaver::vapor::analyzer::_v1::id_expression::_analyze()
         });
 }
 
+std::unique_ptr<reaver::vapor::analyzer::_v1::expression> reaver::vapor::analyzer::_v1::id_expression::_clone_expr_with_replacement(reaver::vapor::analyzer::_v1::replacements & repl) const
+{
+    auto referenced = _referenced;
+
+    auto it = repl.variables.find(referenced);
+    if (it != repl.variables.end())
+    {
+        referenced = it->second;
+    }
+
+    return make_variable_ref_expression(referenced);
+}
+
 reaver::future<reaver::vapor::analyzer::_v1::expression *> reaver::vapor::analyzer::_v1::id_expression::_simplify_expr(reaver::vapor::analyzer::_v1::optimization_context & ctx)
 {
     return _referenced->simplify(ctx)

--- a/analyzer/if.cpp
+++ b/analyzer/if.cpp
@@ -67,6 +67,24 @@ reaver::future<> reaver::vapor::analyzer::_v1::if_statement::_analyze()
     return fut;
 }
 
+std::unique_ptr<reaver::vapor::analyzer::_v1::statement> reaver::vapor::analyzer::if_statement::_clone_with_replacement(reaver::vapor::analyzer::_v1::replacements & repl) const
+{
+    auto ret = std::unique_ptr<if_statement>(new if_statement(*this));
+
+    ret->_condition = _condition->clone_expr_with_replacement(repl);
+
+    auto then = _then_block->clone_with_replacement(repl).release();
+    ret->_then_block.reset(static_cast<block *>(then));
+
+    fmap(_else_block, [&](auto && block) {
+        auto else_ = block->clone_with_replacement(repl).release();
+        ret->_else_block = std::unique_ptr<class block>(static_cast<class block *>(else_));
+        return unit{};
+    });
+
+    return ret;
+}
+
 reaver::future<reaver::vapor::analyzer::_v1::statement *> reaver::vapor::analyzer::_v1::if_statement::_simplify(reaver::vapor::analyzer::_v1::optimization_context & ctx)
 {
     return _condition->simplify_expr(ctx)

--- a/analyzer/integer.cpp
+++ b/analyzer/integer.cpp
@@ -56,17 +56,19 @@ std::unique_ptr<reaver::vapor::analyzer::_v1::type> reaver::vapor::analyzer::_v1
 template<typename Instruction, typename Eval>
 auto reaver::vapor::analyzer::_v1::integer_type::_generate_function(const char32_t * name, const char * desc, Eval eval, reaver::vapor::analyzer::_v1::type * return_type)
 {
+    auto lhs = make_blank_variable(builtin_types().integer.get());
+    auto rhs = make_blank_variable(builtin_types().integer.get());
+
+    auto lhs_arg = lhs.get();
+    auto rhs_arg = rhs.get();
+
     auto fun = make_function(
         desc,
         return_type,
-        { builtin_types().integer.get(), builtin_types().integer.get() },
-        [name, return_type](ir_generation_context & ctx) {
-            auto lhs = codegen::ir::make_variable(
-                builtin_types().integer->codegen_type(ctx)
-            );
-            auto rhs = codegen::ir::make_variable(
-                builtin_types().integer->codegen_type(ctx)
-            );
+        { lhs_arg, rhs_arg },
+        [name, return_type, lhs = std::move(lhs), rhs = std::move(rhs)](ir_generation_context & ctx) {
+            auto lhs_ir = get_ir_variable(lhs->codegen_ir(ctx));
+            auto rhs_ir = get_ir_variable(rhs->codegen_ir(ctx));
 
             auto retval = codegen::ir::make_variable(
                 return_type->codegen_type(ctx)
@@ -74,13 +76,13 @@ auto reaver::vapor::analyzer::_v1::integer_type::_generate_function(const char32
 
             return codegen::ir::function{
                 name,
-                {}, { lhs, rhs },
+                {}, { lhs_ir, rhs_ir },
                 retval,
                 {
                     codegen::ir::instruction{
                         none, none,
                         { boost::typeindex::type_id<Instruction>() },
-                        { lhs, rhs },
+                        { lhs_ir, rhs_ir },
                         retval
                     },
                     codegen::ir::instruction{

--- a/analyzer/integer.cpp
+++ b/analyzer/integer.cpp
@@ -121,6 +121,7 @@ auto reaver::vapor::analyzer::_v1::integer_type::_generate_function(const char32
     }
 
 ADD_OPERATION(addition, U"__builtin_integer_operator_plus", +, integer);
+ADD_OPERATION(subtraction, U"__builtin_integer_operator_minus", -, integer);
 ADD_OPERATION(multiplication, U"__builtin_integer_operator_star", *, integer);
 ADD_OPERATION(equal_comparison, U"__builtin_integer_operator_equals", ==, boolean);
 ADD_OPERATION(less_comparison, U"__builtin_integer_operator_less", <, boolean);

--- a/analyzer/integer.cpp
+++ b/analyzer/integer.cpp
@@ -127,4 +127,5 @@ ADD_OPERATION(subtraction, U"__builtin_integer_operator_minus", -, integer);
 ADD_OPERATION(multiplication, U"__builtin_integer_operator_star", *, integer);
 ADD_OPERATION(equal_comparison, U"__builtin_integer_operator_equals", ==, boolean);
 ADD_OPERATION(less_comparison, U"__builtin_integer_operator_less", <, boolean);
+ADD_OPERATION(less_equal_comparison, U"__builtin_integer_operator_less_equal", <, boolean);
 

--- a/analyzer/integer.cpp
+++ b/analyzer/integer.cpp
@@ -123,4 +123,5 @@ auto reaver::vapor::analyzer::_v1::integer_type::_generate_function(const char32
 ADD_OPERATION(addition, U"__builtin_integer_operator_plus", +, integer);
 ADD_OPERATION(multiplication, U"__builtin_integer_operator_star", *, integer);
 ADD_OPERATION(equal_comparison, U"__builtin_integer_operator_equals", ==, boolean);
+ADD_OPERATION(less_comparison, U"__builtin_integer_operator_less", <, boolean);
 

--- a/analyzer/integer.cpp
+++ b/analyzer/integer.cpp
@@ -26,9 +26,9 @@
 #include "vapor/codegen/ir/variable.h"
 #include "vapor/codegen/ir/type.h"
 
-std::shared_ptr<reaver::vapor::codegen::_v1::ir::variable_type> reaver::vapor::analyzer::_v1::integer_type::_codegen_type(reaver::vapor::analyzer::_v1::ir_generation_context &) const
+void reaver::vapor::analyzer::_v1::integer_type::_codegen_type(reaver::vapor::analyzer::_v1::ir_generation_context &) const
 {
-    return codegen::ir::builtin_types().integer;
+    _codegen_t = codegen::ir::builtin_types().integer;
 }
 
 reaver::vapor::analyzer::_v1::variable_ir reaver::vapor::analyzer::_v1::integer_constant::_codegen_ir(reaver::vapor::analyzer::_v1::ir_generation_context &) const
@@ -95,6 +95,7 @@ auto reaver::vapor::analyzer::_v1::integer_type::_generate_function(const char32
             };
         }
     );
+    fun->set_name(name);
     fun->set_eval(eval);
     return fun;
 }

--- a/analyzer/module.cpp
+++ b/analyzer/module.cpp
@@ -62,7 +62,7 @@ void reaver::vapor::analyzer::_v1::module::analyze()
 
 void reaver::vapor::analyzer::_v1::module::simplify()
 {
-    bool cont = false;
+    bool cont = true;
     while (cont)
     {
         optimization_context ctx{};

--- a/analyzer/overload_set.cpp
+++ b/analyzer/overload_set.cpp
@@ -107,6 +107,11 @@ std::shared_ptr<reaver::vapor::codegen::_v1::ir::variable_type> reaver::vapor::a
     return type;
 }
 
+std::unique_ptr<reaver::vapor::analyzer::_v1::variable> reaver::vapor::analyzer::_v1::overload_set::_clone_with_replacement(reaver::vapor::analyzer::_v1::replacements & repl) const
+{
+    assert(0);
+}
+
 reaver::vapor::analyzer::_v1::variable_ir reaver::vapor::analyzer::_v1::overload_set::_codegen_ir(ir_generation_context & ctx) const
 {
     auto var = codegen::ir::make_variable(_type->codegen_type(ctx));

--- a/analyzer/postfix_expression.cpp
+++ b/analyzer/postfix_expression.cpp
@@ -77,7 +77,6 @@ reaver::future<> reaver::vapor::analyzer::_v1::postfix_expression::_analyze()
         }).then([&]{
             if (!_parse.bracket_type)
             {
-                _set_variable(make_expression_variable(_base_expr.get(), _base_expr->get_type()));
                 return make_ready_future();
             }
 
@@ -167,5 +166,15 @@ reaver::vapor::analyzer::_v1::statement_ir reaver::vapor::analyzer::_v1::postfix
     ret.push_back(std::move(postfix_expr_instruction));
 
     return ret;
+}
+
+reaver::vapor::analyzer::_v1::variable * reaver::vapor::analyzer::_v1::postfix_expression::get_variable() const
+{
+    if (!_parse.bracket_type)
+    {
+        return _base_expr->get_variable();
+    }
+
+    return expression::get_variable();
 }
 

--- a/analyzer/symbol.cpp
+++ b/analyzer/symbol.cpp
@@ -23,17 +23,14 @@
 #include "vapor/analyzer/symbol.h"
 #include "vapor/codegen/ir/variable.h"
 
-std::vector<reaver::variant<std::shared_ptr<reaver::vapor::codegen::_v1::ir::variable>, reaver::vapor::codegen::_v1::ir::function>> reaver::vapor::analyzer::_v1::symbol::codegen_ir(reaver::vapor::analyzer::_v1::ir_generation_context & ctx) const
+reaver::variant<std::shared_ptr<reaver::vapor::codegen::_v1::ir::variable>, std::vector<reaver::vapor::codegen::_v1::ir::function>> reaver::vapor::analyzer::_v1::symbol::codegen_ir(reaver::vapor::analyzer::_v1::ir_generation_context & ctx) const
 {
-    return fmap(_variable->codegen_ir(ctx), [](auto && v) {
-        return fmap(std::forward<decltype(v)>(v), make_overload_set(
-            [](codegen::ir::function f) { return std::move(f); },
-            [](codegen::ir::value val) {
-                return get<std::shared_ptr<codegen::ir::variable>>(fmap(std::move(val), make_overload_set(
-                    [](std::shared_ptr<codegen::ir::variable> var) { return std::move(var); },
-                    [](auto &&) { assert(0); return unit{}; }
-                )));
-            }));
-        });
+    return fmap(_variable->codegen_ir(ctx), make_overload_set(
+        [](none_t) { return std::vector<codegen::ir::function>{}; },
+        [](std::vector<codegen::ir::function> fs) { return fs; },
+        [](codegen::ir::value val) {
+            return get<std::shared_ptr<codegen::ir::variable>>(val);
+        }
+    ));
 }
 

--- a/analyzer/type.cpp
+++ b/analyzer/type.cpp
@@ -23,7 +23,7 @@
 #include "vapor/analyzer/type.h"
 #include "vapor/analyzer/symbol.h"
 
-std::shared_ptr<reaver::vapor::codegen::_v1::ir::variable_type> reaver::vapor::analyzer::_v1::type_type::_codegen_type(reaver::vapor::analyzer::_v1::ir_generation_context &) const
+void reaver::vapor::analyzer::_v1::type_type::_codegen_type(reaver::vapor::analyzer::_v1::ir_generation_context &) const
 {
     assert(0);
 }

--- a/analyzer/variable.cpp
+++ b/analyzer/variable.cpp
@@ -39,6 +39,14 @@ reaver::future<reaver::vapor::analyzer::_v1::variable *> reaver::vapor::analyzer
         });
 }
 
+std::unique_ptr<reaver::vapor::analyzer::_v1::variable> reaver::vapor::analyzer::_v1::expression_variable::_clone_with_replacement(reaver::vapor::analyzer::_v1::replacements & repl) const
+{
+    auto it = repl.expressions.find(_expression);
+    assert(it != repl.expressions.end());
+
+    return make_expression_variable(it->second, _type);
+}
+
 bool reaver::vapor::analyzer::_v1::expression_variable::is_constant() const
 {
     return false;

--- a/codegen/cxx/instruction.cpp
+++ b/codegen/cxx/instruction.cpp
@@ -101,6 +101,7 @@ std::u32string reaver::vapor::codegen::_v1::cxx_generator::generate(const reaver
         ir::integer_multiplication_instruction,
         ir::integer_equal_comparison_instruction,
         ir::integer_less_comparison_instruction,
+        ir::integer_less_equal_comparison_instruction,
 
         ir::boolean_equal_comparison_instruction,
         ir::boolean_negation_instruction

--- a/codegen/cxx/instruction.cpp
+++ b/codegen/cxx/instruction.cpp
@@ -97,8 +97,10 @@ std::u32string reaver::vapor::codegen::_v1::cxx_generator::generate(const reaver
         ir::noop_instruction,
 
         ir::integer_addition_instruction,
+        ir::integer_subtraction_instruction,
         ir::integer_multiplication_instruction,
         ir::integer_equal_comparison_instruction,
+        ir::integer_less_comparison_instruction,
 
         ir::boolean_equal_comparison_instruction,
         ir::boolean_negation_instruction

--- a/codegen/cxx/instructions/int.cpp
+++ b/codegen/cxx/instructions/int.cpp
@@ -33,6 +33,13 @@ std::u32string generate<ir::integer_addition_instruction>(const ir::instruction 
 }
 
 template<>
+std::u32string generate<ir::integer_subtraction_instruction>(const ir::instruction & inst, reaver::vapor::codegen::_v1::codegen_context & ctx)
+{
+    assert(inst.operands.size() == 2);
+    return variable_of(inst.result, ctx) + U".emplace(" + value_of(inst.operands[0], ctx) + U" - " + value_of(inst.operands[1], ctx) + U");\n";
+}
+
+template<>
 std::u32string generate<ir::integer_multiplication_instruction>(const ir::instruction & inst, codegen_context & ctx)
 {
     assert(inst.operands.size() == 2);
@@ -44,6 +51,13 @@ std::u32string generate<ir::integer_equal_comparison_instruction>(const ir::inst
 {
     assert(inst.operands.size() == 2);
     return variable_of(inst.result, ctx) + U".emplace(" + value_of(inst.operands[0], ctx) + U" == " + value_of(inst.operands[1], ctx) + U");\n";
+}
+
+template<>
+std::u32string generate<ir::integer_less_comparison_instruction>(const ir::instruction & inst, codegen_context & ctx)
+{
+    assert(inst.operands.size() == 2);
+    return variable_of(inst.result, ctx) + U".emplace(" + value_of(inst.operands[0], ctx) + U" < " + value_of(inst.operands[1], ctx) + U");\n";
 }
 }}}}}
 

--- a/codegen/cxx/instructions/int.cpp
+++ b/codegen/cxx/instructions/int.cpp
@@ -59,5 +59,12 @@ std::u32string generate<ir::integer_less_comparison_instruction>(const ir::instr
     assert(inst.operands.size() == 2);
     return variable_of(inst.result, ctx) + U".emplace(" + value_of(inst.operands[0], ctx) + U" < " + value_of(inst.operands[1], ctx) + U");\n";
 }
+
+template<>
+std::u32string generate<ir::integer_less_equal_comparison_instruction>(const ir::instruction & inst, codegen_context & ctx)
+{
+    assert(inst.operands.size() == 2);
+    return variable_of(inst.result, ctx) + U".emplace(" + value_of(inst.operands[0], ctx) + U" <= " + value_of(inst.operands[1], ctx) + U");\n";
+}
 }}}}}
 

--- a/include/reaver/vapor/analyzer/argument_list.h
+++ b/include/reaver/vapor/analyzer/argument_list.h
@@ -35,6 +35,7 @@ namespace reaver
         {
             struct argument
             {
+                std::u32string name;
                 std::unique_ptr<expression> type_expression;
                 std::unique_ptr<unresolved_variable> variable;
             };
@@ -45,13 +46,12 @@ namespace reaver
             {
                 return fmap(arglist.arguments, [&](auto && arg) {
                     auto expr = preanalyze_expression(arg.type, lex_scope);
-
-                    auto var = make_unresolved_variable();
+                    auto var = make_unresolved_variable(arg.name.string);
 
                     auto symb = make_symbol(arg.name.string, var.get());
                     lex_scope->init(arg.name.string, std::move(symb));
 
-                    return argument{ std::move(expr), std::move(var) };
+                    return argument{ arg.name.string, std::move(expr), std::move(var) };
                 });
             }
         }}

--- a/include/reaver/vapor/analyzer/argument_list.h
+++ b/include/reaver/vapor/analyzer/argument_list.h
@@ -1,0 +1,60 @@
+/**
+ * Vapor Compiler Licence
+ *
+ * Copyright © 2016 Michał "Griwes" Dominiak
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation is required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ **/
+
+#pragma once
+
+#include "../parser/argument_list.h"
+#include "expression.h"
+#include "symbol.h"
+#include "unresolved_variable.h"
+
+namespace reaver
+{
+    namespace vapor
+    {
+        namespace analyzer { inline namespace _v1
+        {
+            struct argument
+            {
+                std::unique_ptr<expression> type_expression;
+                std::unique_ptr<unresolved_variable> variable;
+            };
+
+            using argument_list = std::vector<argument>;
+
+            inline argument_list preanalyze_argument_list(const parser::argument_list & arglist, scope * lex_scope)
+            {
+                return fmap(arglist.arguments, [&](auto && arg) {
+                    auto expr = preanalyze_expression(arg.type, lex_scope);
+
+                    auto var = make_unresolved_variable();
+
+                    auto symb = make_symbol(arg.name.string, var.get());
+                    lex_scope->init(arg.name.string, std::move(symb));
+
+                    return argument{ std::move(expr), std::move(var) };
+                });
+            }
+        }}
+    }
+}
+

--- a/include/reaver/vapor/analyzer/binary_expression.h
+++ b/include/reaver/vapor/analyzer/binary_expression.h
@@ -45,12 +45,17 @@ namespace reaver
                 virtual void print(std::ostream & os, std::size_t indent) const override;
 
             private:
+                binary_expression(const binary_expression & other) : _parse{ other._parse }, _op{ other._op }, _overload{ other._overload }
+                {
+                }
+
                 virtual future<> _analyze() override;
+                virtual std::unique_ptr<expression> _clone_expr_with_replacement(replacements &) const override;
                 virtual future<expression *> _simplify_expr(optimization_context &) override;
                 virtual statement_ir _codegen_ir(ir_generation_context &) const override;
 
                 const parser::binary_expression & _parse;
-                scope * _scope;
+                scope * _scope = nullptr;
                 lexer::token _op;
                 std::unique_ptr<expression> _lhs;
                 std::unique_ptr<expression> _rhs;

--- a/include/reaver/vapor/analyzer/block.h
+++ b/include/reaver/vapor/analyzer/block.h
@@ -98,6 +98,12 @@ namespace reaver
                 std::vector<std::unique_ptr<statement>> _statements;
                 optional<std::unique_ptr<expression>> _value_expr;
                 const bool _is_top_level = false;
+
+                void _ensure_cache() const;
+
+                mutable std::mutex _clone_cache_lock;
+                bool _is_clone_cache = false;
+                mutable optional<std::unique_ptr<block>> _clone;
             };
 
             inline std::unique_ptr<block> preanalyze_block(const parser::block & parse, scope * lex_scope, bool is_top_level)

--- a/include/reaver/vapor/analyzer/block.h
+++ b/include/reaver/vapor/analyzer/block.h
@@ -83,7 +83,12 @@ namespace reaver
                 codegen::ir::value codegen_return(ir_generation_context &) const;
 
             private:
+                block(const block & other) : _parse{ other._parse }, _original_scope{ other._original_scope }, _is_top_level{ other._is_top_level }
+                {
+                }
+
                 virtual future<> _analyze() override;
+                virtual std::unique_ptr<statement> _clone_with_replacement(replacements &) const override;
                 virtual future<statement *> _simplify(optimization_context &) override;
                 virtual statement_ir _codegen_ir(ir_generation_context &) const override;
 

--- a/include/reaver/vapor/analyzer/block.h
+++ b/include/reaver/vapor/analyzer/block.h
@@ -78,6 +78,11 @@ namespace reaver
                     return _value_expr->get();
                 }
 
+                virtual bool always_returns() const override
+                {
+                    return !_statements.empty() && _statements.back()->always_returns();
+                }
+
                 virtual void print(std::ostream & os, std::size_t indent) const override;
 
                 codegen::ir::value codegen_return(ir_generation_context &) const;

--- a/include/reaver/vapor/analyzer/boolean.h
+++ b/include/reaver/vapor/analyzer/boolean.h
@@ -103,6 +103,11 @@ namespace reaver
                 }
 
             private:
+                virtual std::unique_ptr<variable> _clone_with_replacement(replacements &) const override
+                {
+                    return std::make_unique<boolean_constant>(_value);
+                }
+
                 virtual variable_ir _codegen_ir(ir_generation_context &) const override;
 
                 bool _value;
@@ -128,6 +133,11 @@ namespace reaver
                 virtual future<> _analyze() override
                 {
                     return make_ready_future();
+                }
+
+                virtual std::unique_ptr<expression> _clone_expr_with_replacement(replacements & repl) const override
+                {
+                    return make_variable_expression(_value->clone_with_replacement(repl));
                 }
 
                 virtual future<expression *> _simplify_expr(optimization_context &) override

--- a/include/reaver/vapor/analyzer/boolean.h
+++ b/include/reaver/vapor/analyzer/boolean.h
@@ -57,7 +57,7 @@ namespace reaver
                 }
 
             private:
-                virtual std::shared_ptr<codegen::ir::variable_type> _codegen_type(ir_generation_context &) const override;
+                virtual void _codegen_type(ir_generation_context &) const override;
 
                 template<typename Instruction, typename Eval>
                 static auto _generate_function(const char32_t * name, const char * desc, Eval eval, type * return_type);

--- a/include/reaver/vapor/analyzer/boolean.h
+++ b/include/reaver/vapor/analyzer/boolean.h
@@ -141,10 +141,7 @@ namespace reaver
                 boolean_constant * _value;
             };
 
-            inline std::unique_ptr<type> make_boolean_type()
-            {
-                return std::make_unique<boolean_type>();
-            }
+            std::unique_ptr<type> make_boolean_type();
         }}
     }
 }

--- a/include/reaver/vapor/analyzer/closure.h
+++ b/include/reaver/vapor/analyzer/closure.h
@@ -68,7 +68,7 @@ namespace reaver
                 }
 
             private:
-                virtual std::shared_ptr<codegen::ir::variable_type> _codegen_type(ir_generation_context &) const override;
+                virtual void _codegen_type(ir_generation_context &) const override;
 
                 expression * _closure;
                 std::unique_ptr<function> _function;
@@ -85,6 +85,9 @@ namespace reaver
                     });
                     _scope->close();
 
+                    _return_type = fmap(_parse.return_type, [&](auto && ret_type) {
+                        return preanalyze_expression(ret_type, _scope.get());
+                    });
                     _body = preanalyze_block(parse.body, _scope.get(), true);
                 }
 
@@ -102,11 +105,12 @@ namespace reaver
                 virtual statement_ir _codegen_ir(ir_generation_context &) const override;
 
                 const parser::lambda_expression & _parse;
+                argument_list _argument_list;
+
+                optional<std::unique_ptr<expression>> _return_type;
                 std::unique_ptr<scope> _scope;
                 std::unique_ptr<block> _body;
                 std::unique_ptr<type> _type;
-
-                argument_list _argument_list;
             };
 
             inline std::unique_ptr<closure> preanalyze_closure(const parser::lambda_expression & parse, scope * lex_scope)

--- a/include/reaver/vapor/analyzer/closure.h
+++ b/include/reaver/vapor/analyzer/closure.h
@@ -58,7 +58,7 @@ namespace reaver
                                 _function->arguments().begin(),
                                 true,
                                 std::logical_and<>(),
-                                std::equal_to<>()
+                                [](auto && type, auto && var) { return type == var->get_type(); }
                             ))
                     {
                         return make_ready_future(_function.get());

--- a/include/reaver/vapor/analyzer/closure.h
+++ b/include/reaver/vapor/analyzer/closure.h
@@ -97,6 +97,7 @@ namespace reaver
 
             private:
                 virtual future<> _analyze() override;
+                virtual std::unique_ptr<expression> _clone_expr_with_replacement(replacements &) const override;
                 virtual future<expression *> _simplify_expr(optimization_context &) override;
                 virtual statement_ir _codegen_ir(ir_generation_context &) const override;
 

--- a/include/reaver/vapor/analyzer/declaration.h
+++ b/include/reaver/vapor/analyzer/declaration.h
@@ -95,6 +95,11 @@ namespace reaver
                     });
                 }
 
+                virtual std::unique_ptr<statement> _clone_with_replacement(replacements & repl) const override
+                {
+                    return _init_expr->clone_expr_with_replacement(repl);
+                }
+
                 virtual future<statement *> _simplify(optimization_context & ctx) override
                 {
                     return _init_expr->simplify_expr(ctx)

--- a/include/reaver/vapor/analyzer/expression.h
+++ b/include/reaver/vapor/analyzer/expression.h
@@ -77,6 +77,13 @@ namespace reaver
                     return var->get_type();
                 }
 
+                std::unique_ptr<expression> clone_expr_with_replacement(replacements & repl) const
+                {
+                    auto ret = _clone_expr_with_replacement(repl);
+                    repl.expressions[this] = ret.get();
+                    return ret;
+                }
+
                 future<expression *> simplify_expr(optimization_context & ctx)
                 {
                     return ctx.get_future_or_init(this, [&]() {
@@ -87,6 +94,13 @@ namespace reaver
                 }
 
             protected:
+                virtual std::unique_ptr<statement> _clone_with_replacement(replacements & repl) const override
+                {
+                    return _clone_expr_with_replacement(repl);
+                }
+
+                virtual std::unique_ptr<expression> _clone_expr_with_replacement(replacements & repl) const = 0;
+
                 virtual future<statement *> _simplify(optimization_context & ctx) override final
                 {
                     return simplify_expr(ctx).then([&](auto && simplified) -> statement * {
@@ -116,6 +130,7 @@ namespace reaver
             {
             private:
                 virtual future<> _analyze() override;
+                virtual std::unique_ptr<expression> _clone_expr_with_replacement(replacements &) const override;
                 virtual future<expression *> _simplify_expr(optimization_context &) override;
 
                 virtual statement_ir _codegen_ir(ir_generation_context & ctx) const override
@@ -126,6 +141,8 @@ namespace reaver
                 }
 
             public:
+                expression_list() = default;
+
                 virtual void print(std::ostream & os, std::size_t indent) const override;
 
                 virtual variable * get_variable() const override
@@ -136,47 +153,6 @@ namespace reaver
                 range_type range;
                 std::vector<std::unique_ptr<expression>> value;
             };
-
-            class variable_expression : public expression
-            {
-            public:
-                variable_expression(std::unique_ptr<variable> var)
-                {
-                    _set_variable(std::move(var));
-                }
-
-                virtual void print(std::ostream & os, std::size_t indent) const override;
-
-            private:
-                virtual future<> _analyze() override
-                {
-                    return make_ready_future();
-                }
-
-                virtual future<expression *> _simplify_expr(optimization_context & ctx) override
-                {
-                    return get_variable()->simplify(ctx)
-                        .then([&](auto && simplified) -> expression * {
-                            this->_set_variable(simplified, ctx);
-                            return this;
-                        });
-                }
-
-                virtual statement_ir _codegen_ir(ir_generation_context & ctx) const override
-                {
-                    return { codegen::ir::instruction {
-                        none, none,
-                        { boost::typeindex::type_id<codegen::ir::pass_value_instruction>() },
-                        {},
-                        get<codegen::ir::value>(get_variable()->codegen_ir(ctx))
-                    } };
-                }
-            };
-
-            inline std::unique_ptr<expression> make_variable_expression(std::unique_ptr<variable> var)
-            {
-                return std::make_unique<variable_expression>(std::move(var));
-            }
 
             class variable_ref_expression : public expression
             {
@@ -196,6 +172,17 @@ namespace reaver
                 virtual future<> _analyze() override
                 {
                     return make_ready_future();
+                }
+
+                virtual std::unique_ptr<expression> _clone_expr_with_replacement(replacements & repl) const override
+                {
+                    auto it = repl.variables.find(_referenced);
+                    if (it == repl.variables.end())
+                    {
+                        return std::make_unique<variable_ref_expression>(_referenced);
+                    }
+
+                    return std::make_unique<variable_ref_expression>(it->second);
                 }
 
                 virtual future<expression *> _simplify_expr(optimization_context & ctx) override
@@ -223,6 +210,58 @@ namespace reaver
             inline std::unique_ptr<expression> make_variable_ref_expression(variable * var)
             {
                 return std::make_unique<variable_ref_expression>(var);
+            }
+
+            class variable_expression : public expression
+            {
+            public:
+                variable_expression(std::unique_ptr<variable> var)
+                {
+                    _set_variable(std::move(var));
+                }
+
+                virtual void print(std::ostream & os, std::size_t indent) const override;
+
+            private:
+                virtual future<> _analyze() override
+                {
+                    return make_ready_future();
+                }
+
+                std::unique_ptr<expression> _clone_expr_with_replacement(replacements & repl) const override
+                {
+                    auto it = repl.variables.find(get_variable());
+                    if (it == repl.variables.end())
+                    {
+                        return std::make_unique<variable_expression>(get_variable()->clone_with_replacement(repl));
+                    }
+
+                    return make_variable_ref_expression(it->second);
+                }
+
+                virtual future<expression *> _simplify_expr(optimization_context & ctx) override
+                {
+                    return get_variable()->simplify(ctx)
+                        .then([&](auto && simplified) -> expression * {
+                            this->_set_variable(simplified, ctx);
+                            return this;
+                        });
+                }
+
+                virtual statement_ir _codegen_ir(ir_generation_context & ctx) const override
+                {
+                    return { codegen::ir::instruction {
+                        none, none,
+                        { boost::typeindex::type_id<codegen::ir::pass_value_instruction>() },
+                        {},
+                        get<codegen::ir::value>(get_variable()->codegen_ir(ctx))
+                    } };
+                }
+            };
+
+            inline std::unique_ptr<expression> make_variable_expression(std::unique_ptr<variable> var)
+            {
+                return std::make_unique<variable_expression>(std::move(var));
             }
 
             std::unique_ptr<expression> preanalyze_expression(const parser::expression & expr, scope * lex_scope);

--- a/include/reaver/vapor/analyzer/expression.h
+++ b/include/reaver/vapor/analyzer/expression.h
@@ -168,7 +168,7 @@ namespace reaver
                         none, none,
                         { boost::typeindex::type_id<codegen::ir::pass_value_instruction>() },
                         {},
-                        codegen::ir::value{ get<0>(get_variable()->codegen_ir(ctx).back()) }
+                        get<codegen::ir::value>(get_variable()->codegen_ir(ctx))
                     } };
                 }
             };
@@ -213,7 +213,7 @@ namespace reaver
                         none, none,
                         { boost::typeindex::type_id<codegen::ir::pass_value_instruction>() },
                         {},
-                        codegen::ir::value{ get<0>(_referenced->codegen_ir(ctx).back()) }
+                        get<codegen::ir::value>(_referenced->codegen_ir(ctx))
                     } };
                 }
 

--- a/include/reaver/vapor/analyzer/expression.h
+++ b/include/reaver/vapor/analyzer/expression.h
@@ -128,6 +128,11 @@ namespace reaver
             public:
                 virtual void print(std::ostream & os, std::size_t indent) const override;
 
+                virtual variable * get_variable() const override
+                {
+                    return value.back()->get_variable();
+                }
+
                 range_type range;
                 std::vector<std::unique_ptr<expression>> value;
             };

--- a/include/reaver/vapor/analyzer/function.h
+++ b/include/reaver/vapor/analyzer/function.h
@@ -48,9 +48,9 @@ namespace reaver
             class function
             {
             public:
-                function(std::string explanation, type * ret, std::vector<type *> args, function_codegen codegen, optional<range_type> range = none)
+                function(std::string explanation, type * ret, std::vector<variable *> args, function_codegen codegen, optional<range_type> range = none)
                     : _explanation{ std::move(explanation) }, _range{ std::move(range) },
-                    _return_type{ ret }, _argument_types{ std::move(args) }, _codegen{ std::move(codegen) }
+                    _return_type{ ret }, _arguments{ std::move(args) }, _codegen{ std::move(codegen) }
                 {
                     if (ret)
                     {
@@ -68,9 +68,9 @@ namespace reaver
                     return *_return_type_future;
                 }
 
-                std::vector<type *> arguments() const
+                std::vector<variable *> arguments() const
                 {
-                    return _argument_types;
+                    return _arguments;
                 }
 
                 std::string explain() const
@@ -131,9 +131,9 @@ namespace reaver
                     _compile_time_eval = std::move(eval);
                 }
 
-                void set_arguments(std::vector<type *> arg_types)
+                void set_arguments(std::vector<variable *> args)
                 {
-                    _argument_types = std::move(arg_types);
+                    _arguments = std::move(args);
                 }
 
             private:
@@ -146,14 +146,14 @@ namespace reaver
                 optional<future<type *>> _return_type_future;
                 optional<manual_promise<type *>> _return_type_promise;
 
-                std::vector<type *> _argument_types;
+                std::vector<variable *> _arguments;
                 function_codegen _codegen;
                 mutable optional<codegen::ir::function> _ir;
 
                 optional<function_eval> _compile_time_eval;
             };
 
-            inline std::unique_ptr<function> make_function(std::string expl, type * return_type, std::vector<type *> arguments, function_codegen codegen, optional<range_type> range = none)
+            inline std::unique_ptr<function> make_function(std::string expl, type * return_type, std::vector<variable *> arguments, function_codegen codegen, optional<range_type> range = none)
             {
                 return std::make_unique<function>(std::move(expl), std::move(return_type), std::move(arguments), std::move(codegen), std::move(range));
             }

--- a/include/reaver/vapor/analyzer/function.h
+++ b/include/reaver/vapor/analyzer/function.h
@@ -131,6 +131,11 @@ namespace reaver
                     _compile_time_eval = std::move(eval);
                 }
 
+                void set_arguments(std::vector<type *> arg_types)
+                {
+                    _argument_types = std::move(arg_types);
+                }
+
             private:
                 std::string _explanation;
                 optional<range_type> _range;

--- a/include/reaver/vapor/analyzer/function.h
+++ b/include/reaver/vapor/analyzer/function.h
@@ -111,7 +111,8 @@ namespace reaver
 
                 codegen::ir::value call_operand_ir(ir_generation_context & ctx) const
                 {
-                    return { codegen::ir::label{ codegen_ir(ctx).name, {} } };
+                    assert(_name);
+                    return { codegen::ir::label{ *_name, {} } };
                 }
 
                 void set_return_type(type * ret)
@@ -121,9 +122,19 @@ namespace reaver
                     fmap(_return_type_promise, [ret](auto && promise) { promise.set(ret); return unit{}; });
                 }
 
+                void set_name(std::u32string name)
+                {
+                    _name = name;
+                }
+
                 void set_body(block * body)
                 {
                     _body = body;
+                }
+
+                block * get_body() const
+                {
+                    return _body;
                 }
 
                 void set_eval(function_eval eval)
@@ -147,6 +158,7 @@ namespace reaver
                 optional<manual_promise<type *>> _return_type_promise;
 
                 std::vector<variable *> _arguments;
+                optional<std::u32string> _name;
                 function_codegen _codegen;
                 mutable optional<codegen::ir::function> _ir;
 

--- a/include/reaver/vapor/analyzer/id_expression.h
+++ b/include/reaver/vapor/analyzer/id_expression.h
@@ -57,6 +57,7 @@ namespace reaver
 
             private:
                 virtual future<> _analyze() override;
+                std::unique_ptr<expression> _clone_expr_with_replacement(replacements &) const override;
                 virtual future<expression *> _simplify_expr(optimization_context &) override;
                 virtual statement_ir _codegen_ir(ir_generation_context &) const override;
 

--- a/include/reaver/vapor/analyzer/if.h
+++ b/include/reaver/vapor/analyzer/if.h
@@ -56,7 +56,12 @@ namespace reaver
                 virtual void print(std::ostream & os, std::size_t indent) const override;
 
             private:
+                if_statement(const if_statement & other) : _parse{ other._parse }
+                {
+                }
+
                 virtual future<> _analyze() override;
+                virtual std::unique_ptr<statement> _clone_with_replacement(replacements &) const override;
                 virtual future<statement *> _simplify(optimization_context &) override;
                 virtual statement_ir _codegen_ir(ir_generation_context &) const override;
 

--- a/include/reaver/vapor/analyzer/integer.h
+++ b/include/reaver/vapor/analyzer/integer.h
@@ -121,6 +121,11 @@ namespace reaver
                 }
 
             private:
+                virtual std::unique_ptr<variable> _clone_with_replacement(replacements &) const override
+                {
+                    return std::make_unique<integer_constant>(_value);
+                }
+
                 virtual variable_ir _codegen_ir(ir_generation_context &) const override;
 
                 boost::multiprecision::cpp_int _value;
@@ -146,6 +151,11 @@ namespace reaver
                 virtual future<> _analyze() override
                 {
                     return make_ready_future();
+                }
+
+                virtual std::unique_ptr<expression> _clone_expr_with_replacement(replacements & repl) const override
+                {
+                    return make_variable_expression(_value->clone_with_replacement(repl));
                 }
 
                 virtual future<expression *> _simplify_expr(optimization_context &) override

--- a/include/reaver/vapor/analyzer/integer.h
+++ b/include/reaver/vapor/analyzer/integer.h
@@ -54,6 +54,9 @@ namespace reaver
                         case lexer::token_type::equals:
                             return make_ready_future(_equal_comparison());
 
+                        case lexer::token_type::less:
+                            return make_ready_future(_less_comparison());
+
                         default:
                             assert(!"unimplemented int op");
                     }
@@ -72,6 +75,7 @@ namespace reaver
                 static function * _addition();
                 static function * _multiplication();
                 static function * _equal_comparison();
+                static function * _less_comparison();
             };
 
             class integer_constant : public literal

--- a/include/reaver/vapor/analyzer/integer.h
+++ b/include/reaver/vapor/analyzer/integer.h
@@ -74,7 +74,7 @@ namespace reaver
                 }
 
             private:
-                virtual std::shared_ptr<codegen::ir::variable_type> _codegen_type(ir_generation_context &) const override;
+                virtual void _codegen_type(ir_generation_context &) const override;
 
                 template<typename Instruction, typename Eval>
                 static auto _generate_function(const char32_t * name, const char * desc, Eval eval, type * return_type);

--- a/include/reaver/vapor/analyzer/integer.h
+++ b/include/reaver/vapor/analyzer/integer.h
@@ -48,6 +48,9 @@ namespace reaver
                         case lexer::token_type::plus:
                             return make_ready_future(_addition());
 
+                        case lexer::token_type::minus:
+                            return make_ready_future(_subtraction());
+
                         case lexer::token_type::star:
                             return make_ready_future(_multiplication());
 
@@ -73,6 +76,7 @@ namespace reaver
                 template<typename Instruction, typename Eval>
                 static auto _generate_function(const char32_t * name, const char * desc, Eval eval, type * return_type);
                 static function * _addition();
+                static function * _subtraction();
                 static function * _multiplication();
                 static function * _equal_comparison();
                 static function * _less_comparison();

--- a/include/reaver/vapor/analyzer/integer.h
+++ b/include/reaver/vapor/analyzer/integer.h
@@ -60,6 +60,9 @@ namespace reaver
                         case lexer::token_type::less:
                             return make_ready_future(_less_comparison());
 
+                        case lexer::token_type::less_equal:
+                            return make_ready_future(_less_equal_comparison());
+
                         default:
                             assert(!"unimplemented int op");
                     }
@@ -80,6 +83,7 @@ namespace reaver
                 static function * _multiplication();
                 static function * _equal_comparison();
                 static function * _less_comparison();
+                static function * _less_equal_comparison();
             };
 
             class integer_constant : public literal

--- a/include/reaver/vapor/analyzer/overload_set.h
+++ b/include/reaver/vapor/analyzer/overload_set.h
@@ -90,6 +90,7 @@ namespace reaver
                 }
 
             private:
+                virtual std::unique_ptr<variable> _clone_with_replacement(replacements &) const override;
                 virtual variable_ir _codegen_ir(ir_generation_context &) const override;
 
                 std::vector<function_declaration *> _overloads;
@@ -127,6 +128,12 @@ namespace reaver
 
             private:
                 virtual future<> _analyze() override;
+
+                virtual std::unique_ptr<statement> _clone_with_replacement(replacements &) const override
+                {
+                    return make_null_statement();
+                }
+
                 virtual future<statement *> _simplify(optimization_context &) override;
                 virtual statement_ir _codegen_ir(ir_generation_context &) const override;
 

--- a/include/reaver/vapor/analyzer/postfix_expression.h
+++ b/include/reaver/vapor/analyzer/postfix_expression.h
@@ -44,6 +44,7 @@ namespace reaver
                 postfix_expression(const parser::postfix_expression & parse, scope * lex_scope);
 
                 virtual void print(std::ostream & os, std::size_t indent) const override;
+                virtual variable * get_variable() const override;
 
             private:
                 virtual future<> _analyze() override;

--- a/include/reaver/vapor/analyzer/postfix_expression.h
+++ b/include/reaver/vapor/analyzer/postfix_expression.h
@@ -47,12 +47,17 @@ namespace reaver
                 virtual variable * get_variable() const override;
 
             private:
+                postfix_expression(const postfix_expression & other) : _parse{ other._parse }, _brace{ other._brace }, _overload{ other._overload }
+                {
+                }
+
                 virtual future<> _analyze() override;
+                virtual std::unique_ptr<expression> _clone_expr_with_replacement(replacements &) const override;
                 virtual future<expression *> _simplify_expr(optimization_context &) override;
                 virtual statement_ir _codegen_ir(ir_generation_context &) const override;
 
                 const parser::postfix_expression & _parse;
-                scope * _scope;
+                scope * _scope = nullptr;
                 std::unique_ptr<expression> _base_expr;
                 optional<lexer::token_type> _brace;
                 std::vector<std::unique_ptr<expression>> _arguments;

--- a/include/reaver/vapor/analyzer/return.h
+++ b/include/reaver/vapor/analyzer/return.h
@@ -64,6 +64,19 @@ namespace reaver
                     return _value_expr->analyze();
                 }
 
+                return_statement(const return_statement & other) : _parse{ other._parse }
+                {
+                }
+
+                virtual std::unique_ptr<statement> _clone_with_replacement(replacements & repl) const override
+                {
+                    auto ret = std::unique_ptr<return_statement>(new return_statement(*this));
+
+                    ret->_value_expr = _value_expr->clone_expr_with_replacement(repl);
+
+                    return ret;
+                }
+
                 virtual future<statement *> _simplify(optimization_context & ctx) override
                 {
                     return _value_expr->simplify_expr(ctx).then([&](auto && simplified) -> statement * {

--- a/include/reaver/vapor/analyzer/return.h
+++ b/include/reaver/vapor/analyzer/return.h
@@ -56,6 +56,11 @@ namespace reaver
                     return _value_expr->get_variable();
                 }
 
+                virtual bool always_returns() const override
+                {
+                    return true;
+                }
+
                 virtual void print(std::ostream & os, std::size_t indent) const override;
 
             private:

--- a/include/reaver/vapor/analyzer/scope.h
+++ b/include/reaver/vapor/analyzer/scope.h
@@ -53,6 +53,8 @@ namespace reaver
 
             class symbol;
 
+            const std::unordered_map<std::u32string, std::unique_ptr<symbol>> & non_overridable();
+
             class scope
             {
                 struct _key {};
@@ -127,6 +129,11 @@ namespace reaver
                 template<typename F>
                 auto get_or_init(const std::u32string & name, F init)
                 {
+                    if (non_overridable().find(name) != non_overridable().end())
+                    {
+                        assert(0);
+                    }
+
                     assert(!_is_closed);
 
                     {

--- a/include/reaver/vapor/analyzer/statement.h
+++ b/include/reaver/vapor/analyzer/statement.h
@@ -59,6 +59,17 @@ namespace reaver
                         if (!_is_future_assigned)
                         {
                             _analysis_future = _analyze();
+                            _analysis_future->on_error([](std::exception_ptr ptr){
+                                try
+                                {
+                                    std::rethrow_exception(ptr);
+                                }
+
+                                catch (...)
+                                {
+                                    std::terminate();
+                                }
+                            }).detach(); // this is wrooong
                             _is_future_assigned = true;
                         }
                     }

--- a/include/reaver/vapor/analyzer/statement.h
+++ b/include/reaver/vapor/analyzer/statement.h
@@ -118,6 +118,11 @@ namespace reaver
                     return {};
                 }
 
+                virtual bool always_returns() const
+                {
+                    return false;
+                }
+
                 virtual void print(std::ostream &, std::size_t indent) const = 0;
 
                 statement_ir codegen_ir(ir_generation_context & ctx) const

--- a/include/reaver/vapor/analyzer/symbol.h
+++ b/include/reaver/vapor/analyzer/symbol.h
@@ -105,7 +105,7 @@ namespace reaver
                         });
                 }
 
-                std::vector<variant<std::shared_ptr<codegen::ir::variable>, codegen::ir::function>> codegen_ir(ir_generation_context &) const;
+                variant<std::shared_ptr<codegen::ir::variable>, std::vector<codegen::ir::function>> codegen_ir(ir_generation_context &) const;
 
             private:
                 mutable std::shared_mutex _lock;

--- a/include/reaver/vapor/analyzer/type.h
+++ b/include/reaver/vapor/analyzer/type.h
@@ -29,6 +29,7 @@
 #include "../lexer/token.h"
 #include "scope.h"
 #include "ir_context.h"
+#include "../codegen/ir/type.h"
 
 namespace reaver
 {
@@ -80,16 +81,19 @@ namespace reaver
                 {
                     if (!_codegen_t)
                     {
-                        _codegen_t = _codegen_type(ctx);
+                        _codegen_t = std::make_shared<codegen::ir::variable_type>();
+                        _codegen_type(ctx);
                     }
 
                     return *_codegen_t;
                 }
 
             private:
-                virtual std::shared_ptr<codegen::ir::variable_type> _codegen_type(ir_generation_context &) const = 0;
+                virtual void _codegen_type(ir_generation_context &) const = 0;
 
                 std::unique_ptr<scope> _lex_scope;
+
+            protected:
                 mutable optional<std::shared_ptr<codegen::ir::variable_type>> _codegen_t;
             };
 
@@ -102,7 +106,7 @@ namespace reaver
                 }
 
             private:
-                virtual std::shared_ptr<codegen::ir::variable_type> _codegen_type(ir_generation_context &) const override;
+                virtual void _codegen_type(ir_generation_context &) const override;
             };
 
             // these here are currently kinda silly

--- a/include/reaver/vapor/analyzer/type.h
+++ b/include/reaver/vapor/analyzer/type.h
@@ -61,12 +61,12 @@ namespace reaver
 
                 virtual future<function *> get_overload(lexer::token_type, const type *) const
                 {
-                    return make_ready_future<function *>(nullptr);
+                    return make_ready_future(static_cast<function *>(nullptr));
                 }
 
                 virtual future<function *> get_overload(lexer::token_type, std::vector<const type *>) const
                 {
-                    return make_ready_future<function *>(nullptr);
+                    return make_ready_future(static_cast<function *>(nullptr));
                 }
 
                 virtual std::string explain() const = 0;

--- a/include/reaver/vapor/analyzer/type_variable.h
+++ b/include/reaver/vapor/analyzer/type_variable.h
@@ -1,0 +1,72 @@
+/**
+ * Vapor Compiler Licence
+ *
+ * Copyright © 2016 Michał "Griwes" Dominiak
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation is required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ **/
+
+#pragma once
+
+#include "type.h"
+#include "variable.h"
+
+namespace reaver
+{
+    namespace vapor
+    {
+        namespace analyzer { inline namespace _v1
+        {
+            class type_variable : public variable
+            {
+            public:
+                type_variable(type * t) : _type{ t }
+                {
+                }
+
+                virtual type * get_type() const override
+                {
+                    return builtin_types().type.get();
+                }
+
+                type * get_value() const
+                {
+                    return _type;
+                }
+
+                virtual bool is_constant() const override
+                {
+                    return _type;
+                }
+
+            private:
+                virtual variable_ir _codegen_ir(ir_generation_context &) const override
+                {
+                    return {};
+                }
+
+                type * _type;
+            };
+
+            inline auto make_type_variable(type * t)
+            {
+                return std::make_unique<type_variable>(t);
+            }
+        }}
+    }
+}
+

--- a/include/reaver/vapor/analyzer/type_variable.h
+++ b/include/reaver/vapor/analyzer/type_variable.h
@@ -56,7 +56,7 @@ namespace reaver
             private:
                 virtual variable_ir _codegen_ir(ir_generation_context &) const override
                 {
-                    return {};
+                    return none;
                 }
 
                 type * _type;

--- a/include/reaver/vapor/analyzer/type_variable.h
+++ b/include/reaver/vapor/analyzer/type_variable.h
@@ -54,6 +54,11 @@ namespace reaver
                 }
 
             private:
+                virtual std::unique_ptr<variable> _clone_with_replacement(replacements &) const override
+                {
+                    return std::make_unique<type_variable>(_type);
+                }
+
                 virtual variable_ir _codegen_ir(ir_generation_context &) const override
                 {
                     return none;

--- a/include/reaver/vapor/analyzer/unary_expression.h
+++ b/include/reaver/vapor/analyzer/unary_expression.h
@@ -50,6 +50,11 @@ namespace reaver
                     assert(0);
                 }
 
+                virtual std::unique_ptr<expression> _clone_expr_with_replacement(replacements &) const override
+                {
+                    assert(0);
+                }
+
                 virtual future<expression *> _simplify_expr(optimization_context &) override
                 {
                     assert(0);

--- a/include/reaver/vapor/analyzer/unresolved_variable.h
+++ b/include/reaver/vapor/analyzer/unresolved_variable.h
@@ -57,6 +57,16 @@ namespace reaver
                 }
 
             private:
+                virtual std::unique_ptr<variable> _clone_with_replacement(replacements &) const override
+                {
+                    auto ret = std::make_unique<unresolved_variable>(_name);
+                    if (_type)
+                    {
+                        ret->set_type(_type);
+                    }
+                    return ret;
+                }
+
                 // TODO: there's a chance this should be an assert
                 // and that this all should be replaced during simplification
                 // but for now, this also has to work

--- a/include/reaver/vapor/analyzer/unresolved_variable.h
+++ b/include/reaver/vapor/analyzer/unresolved_variable.h
@@ -1,0 +1,76 @@
+/**
+ * Vapor Compiler Licence
+ *
+ * Copyright © 2016 Michał "Griwes" Dominiak
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation is required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ **/
+
+#pragma once
+
+#include "variable.h"
+#include "type.h"
+#include "expression.h"
+#include "type_variable.h"
+
+namespace reaver
+{
+    namespace vapor
+    {
+        namespace analyzer { inline namespace _v1
+        {
+            class unresolved_variable : public variable
+            {
+            public:
+                unresolved_variable()
+                {
+                }
+
+                virtual type * get_type() const override
+                {
+                    if (_type)
+                    {
+                        return _type->get_value();
+                    }
+
+                    assert(0);
+                }
+
+                void set_type(variable * type)
+                {
+                    assert(type && type->get_type() == builtin_types().type.get());
+                    _type = dynamic_cast<type_variable *>(type);
+                    assert(_type);
+                }
+
+            private:
+                virtual variable_ir _codegen_ir(ir_generation_context &) const override
+                {
+                    assert(0);
+                }
+
+                type_variable * _type = nullptr;
+            };
+
+            inline std::unique_ptr<unresolved_variable> make_unresolved_variable()
+            {
+                return std::make_unique<unresolved_variable>();
+            }
+        }}
+    }
+}
+

--- a/include/reaver/vapor/analyzer/unresolved_variable.h
+++ b/include/reaver/vapor/analyzer/unresolved_variable.h
@@ -36,7 +36,7 @@ namespace reaver
             class unresolved_variable : public variable
             {
             public:
-                unresolved_variable()
+                unresolved_variable(std::u32string name) : _name{ std::move(name) }
                 {
                 }
 
@@ -54,21 +54,30 @@ namespace reaver
                 {
                     assert(type && type->get_type() == builtin_types().type.get());
                     _type = dynamic_cast<type_variable *>(type);
-                    assert(_type);
                 }
 
             private:
-                virtual variable_ir _codegen_ir(ir_generation_context &) const override
+                // TODO: there's a chance this should be an assert
+                // and that this all should be replaced during simplification
+                // but for now, this also has to work
+                virtual variable_ir _codegen_ir(ir_generation_context & ctx) const override
                 {
-                    assert(0);
+                    assert(_type && _type->get_value());
+                    return {
+                        codegen::ir::make_variable(
+                            _type->get_value()->codegen_type(ctx),
+                            _name
+                        )
+                    };
                 }
 
                 type_variable * _type = nullptr;
+                std::u32string _name;
             };
 
-            inline std::unique_ptr<unresolved_variable> make_unresolved_variable()
+            inline std::unique_ptr<unresolved_variable> make_unresolved_variable(std::u32string name)
             {
-                return std::make_unique<unresolved_variable>();
+                return std::make_unique<unresolved_variable>(std::move(name));
             }
         }}
     }

--- a/include/reaver/vapor/analyzer/variable.h
+++ b/include/reaver/vapor/analyzer/variable.h
@@ -43,6 +43,13 @@ namespace reaver
 
             using variable_ir = variant<none_t, codegen::ir::value, std::vector<codegen::ir::function>>;
 
+            inline auto get_ir_variable(const variable_ir & ir)
+            {
+                return get<std::shared_ptr<codegen::ir::variable>>(
+                    get<codegen::ir::value>(ir)
+                );
+            }
+
             class variable
             {
             public:
@@ -116,6 +123,34 @@ namespace reaver
             inline std::unique_ptr<variable> make_expression_variable(expression * expr, type * type)
             {
                 return std::make_unique<expression_variable>(expr, type);
+            }
+
+            class blank_variable : public variable
+            {
+            public:
+                blank_variable(type * t) : _type{ t }
+                {
+                }
+
+                virtual type * get_type() const override
+                {
+                    return _type;
+                }
+
+            private:
+                virtual variable_ir _codegen_ir(ir_generation_context & ctx) const override
+                {
+                    return codegen::ir::make_variable(
+                        _type->codegen_type(ctx)
+                    );
+                }
+
+                type * _type;
+            };
+
+            inline std::unique_ptr<variable> make_blank_variable(type * type)
+            {
+                return std::make_unique<blank_variable>(type);
             }
         }}
     }

--- a/include/reaver/vapor/analyzer/variable.h
+++ b/include/reaver/vapor/analyzer/variable.h
@@ -78,7 +78,14 @@ namespace reaver
                 {
                     if (!_ir)
                     {
-                        _ir = _codegen_ir(ctx);
+                        auto ir = _codegen_ir(ctx);
+                        // this if guards from inconsistencies arising from reentry into this function
+                        // this way of solving this can sometimes cause additional work to be done
+                        // TODO: figure out how to stop that from happening
+                        if (!_ir)
+                        {
+                            _ir = std::move(ir);
+                        }
                     }
 
                     return *_ir;

--- a/include/reaver/vapor/analyzer/variable.h
+++ b/include/reaver/vapor/analyzer/variable.h
@@ -24,6 +24,8 @@
 
 #include <memory>
 
+#include <reaver/optional.h>
+
 #include "type.h"
 #include "../codegen/ir/variable.h"
 #include "../codegen/ir/function.h"
@@ -39,7 +41,7 @@ namespace reaver
             class type;
             class expression;
 
-            using variable_ir = std::vector<variant<codegen::ir::value, codegen::ir::function>>;
+            using variable_ir = variant<none_t, codegen::ir::value, std::vector<codegen::ir::function>>;
 
             class variable
             {

--- a/include/reaver/vapor/codegen/ir/integer.h
+++ b/include/reaver/vapor/codegen/ir/integer.h
@@ -42,6 +42,7 @@ namespace reaver
                 struct integer_multiplication_instruction {};
                 struct integer_equal_comparison_instruction {};
                 struct integer_less_comparison_instruction {};
+                struct integer_less_equal_comparison_instruction {};
             }
         }}
     }

--- a/include/reaver/vapor/codegen/ir/integer.h
+++ b/include/reaver/vapor/codegen/ir/integer.h
@@ -40,6 +40,7 @@ namespace reaver
                 struct integer_addition_instruction {};
                 struct integer_multiplication_instruction {};
                 struct integer_equal_comparison_instruction {};
+                struct integer_less_comparison_instruction {};
             }
         }}
     }

--- a/include/reaver/vapor/codegen/ir/integer.h
+++ b/include/reaver/vapor/codegen/ir/integer.h
@@ -38,6 +38,7 @@ namespace reaver
                 };
 
                 struct integer_addition_instruction {};
+                struct integer_subtraction_instruction {};
                 struct integer_multiplication_instruction {};
                 struct integer_equal_comparison_instruction {};
                 struct integer_less_comparison_instruction {};

--- a/include/reaver/vapor/codegen/ir/module.h
+++ b/include/reaver/vapor/codegen/ir/module.h
@@ -36,10 +36,12 @@ namespace reaver
         {
             namespace ir
             {
+                using module_symbols_t = std::vector<variant<std::shared_ptr<variable>, function>>;
+
                 struct module
                 {
                     std::vector<std::u32string> name;
-                    std::vector<variant<std::shared_ptr<variable>, function>> symbols;
+                    module_symbols_t symbols;
                 };
 
                 std::ostream & operator<<(std::ostream & os, const module & mod);

--- a/include/reaver/vapor/codegen/ir/type.h
+++ b/include/reaver/vapor/codegen/ir/type.h
@@ -88,11 +88,6 @@ namespace reaver
                     return os;
                 }
 
-                inline auto make_type(std::u32string name, std::vector<scope> scopes, std::size_t size, std::vector<member> members)
-                {
-                    return std::make_shared<variable_type>(variable_type{ std::move(name), std::move(scopes), size, std::move(members) });
-                }
-
                 inline const auto & builtin_types()
                 {
                     struct builtin_types_t

--- a/include/reaver/vapor/parser/argument_list.h
+++ b/include/reaver/vapor/parser/argument_list.h
@@ -24,6 +24,7 @@
 
 #include "../range.h"
 #include "helpers.h"
+#include "expression.h"
 
 namespace reaver
 {
@@ -31,17 +32,35 @@ namespace reaver
     {
         namespace parser { inline namespace _v1
         {
+            struct argument
+            {
+                range_type range;
+                lexer::token name;
+                expression type;
+            };
+
             struct argument_list
             {
                 range_type range;
+                std::vector<argument> arguments;
             };
+
+            inline bool operator==(const argument & lhs, const argument & rhs)
+            {
+                return lhs.range == rhs.range
+                    && lhs.name == rhs.name
+                    && lhs.type == rhs.type;
+            }
 
             inline bool operator==(const argument_list & lhs, const argument_list & rhs)
             {
-                return lhs.range == rhs.range;
+                return lhs.range == rhs.range
+                    && lhs.arguments == rhs.arguments;
             }
 
             argument_list parse_argument_list(context & ctx);
+
+            void print(const argument_list &, std::ostream &, std::size_t indent);
         }}
     }
 }

--- a/include/reaver/vapor/parser/expression.h
+++ b/include/reaver/vapor/parser/expression.h
@@ -77,7 +77,7 @@ namespace reaver
                     && lhs.expression_value == rhs.expression_value;
             }
 
-            expression parse_expression(context & ctx, bool special_assignment = false);
+            expression parse_expression(context & ctx, expression_special_modes = expression_special_modes::none);
 
             void print(const expression & expr, std::ostream & os, std::size_t indent = 0);
         }}

--- a/include/reaver/vapor/parser/helpers.h
+++ b/include/reaver/vapor/parser/helpers.h
@@ -69,6 +69,13 @@ namespace reaver
                 operator_type type;
             };
 
+            enum class expression_special_modes
+            {
+                none,
+                assignment,
+                brace
+            };
+
             struct context
             {
                 lexer::iterator begin, end;

--- a/include/reaver/vapor/parser/lambda_expression.h
+++ b/include/reaver/vapor/parser/lambda_expression.h
@@ -41,6 +41,7 @@ namespace reaver
                 range_type range;
                 optional<capture_list> captures;
                 optional<argument_list> arguments;
+                optional<expression> return_type;
                 block body;
             };
 
@@ -49,6 +50,7 @@ namespace reaver
                 return lhs.range == rhs.range
                     && lhs.captures == rhs.captures
                     && lhs.arguments == rhs.arguments
+                    && lhs.return_type == rhs.return_type
                     && lhs.body == rhs.body;
             }
 

--- a/include/reaver/vapor/parser/postfix_expression.h
+++ b/include/reaver/vapor/parser/postfix_expression.h
@@ -53,7 +53,7 @@ namespace reaver
                     && lhs.arguments == rhs.arguments;
             }
 
-            postfix_expression parse_postfix_expression(context & ctx);
+            postfix_expression parse_postfix_expression(context & ctx, expression_special_modes = expression_special_modes::none);
 
             void print(const postfix_expression & expr, std::ostream & os, std::size_t indent = 0);
         }}

--- a/lexer/lexer.cpp
+++ b/lexer/lexer.cpp
@@ -60,6 +60,7 @@ static auto token_types_init = []() -> reaver::unit
     token_types[+token_type::colon] = ":";
     token_types[+token_type::semicolon] = ";";
     token_types[+token_type::map] = "->>";
+    token_types[+token_type::indirection] = "->";
     token_types[+token_type::assign] = "=";
     token_types[+token_type::block_value] = "=>";
 
@@ -190,6 +191,7 @@ const std::unordered_map<char32_t, std::unordered_map<char32_t, token_type>> rea
     } },
 
     { '-', {
+        { '>', token_type::indirection },
         { '=', token_type::minus_assignment }
     } },
 

--- a/main.cpp
+++ b/main.cpp
@@ -37,12 +37,12 @@ std::u32string program = UR"program(module hello_world
             return 0;
         }
 
-        else { if (n == 1)
+        else if (n == 1)
         {
             return 1;
         }
 
-        else { if (n == 2)
+        else if (n == 2)
         {
             return 1;
         }
@@ -50,7 +50,7 @@ std::u32string program = UR"program(module hello_world
         else
         {
             return fibonacci(n - 1) + fibonacci(n - 2);
-        }}}
+        }
     }
 
     let entry = λ(arg : int) -> int

--- a/main.cpp
+++ b/main.cpp
@@ -50,11 +50,11 @@ std::u32string program = UR"program(module hello_world
         }
     }
 
-    function entry(arg : int)
+    let entry = λ(arg : int)
     {
         let partial = foo() + bar();
         return partial + conditional(100, arg);
-    }
+    };
 })program";
 
 int main() try

--- a/main.cpp
+++ b/main.cpp
@@ -30,32 +30,32 @@
 
 std::u32string program = UR"program(module hello_world
 {
-    let foo = λ => 1 * 2 + 3 * 4;
-
-    let foobar = int;
-
-    function bar()
+    function fibonacci(n : int)
     {
-        return 5 + 6 * 7 + 8;
-    }
-
-    function conditional(x : foobar, y : int)
-    {
-        if (x * y < 123)
+        if (n == 0)
         {
-            return x + y;
+            return 0;
         }
 
-        else
+        if (n == 1)
         {
-            return x - y;
+            return 1;
         }
+
+        if (n == 2)
+        {
+            return 1;
+        }
+
+        return fibonacci(n - 1) + fibonacci(n - 2);
     }
 
     let entry = λ(arg : int)
     {
-        let partial = foo() + bar();
-        return arg + conditional(100, partial);
+        let constant_foldable = fibonacci(7);
+        let non_constant_foldable = fibonacci(arg);
+
+        return constant_foldable + non_constant_foldable;
     };
 })program";
 

--- a/main.cpp
+++ b/main.cpp
@@ -37,28 +37,23 @@ std::u32string program = UR"program(module hello_world
         return 5 + 6 * 7 + 8;
     }
 
-    function conditional()
+    function conditional(x : int, y : int)
     {
-        if (false)
+        if (x * y < 123)
         {
-            return 0;
-        }
-
-        else if (2 + 2 == 7)
-        {
-            return 0;
+            return x + y;
         }
 
         else
         {
-            return 1;
+            return x - y;
         }
     }
 
-    function entry()
+    function entry(arg : int)
     {
         let partial = foo() + bar();
-        return partial + conditional();
+        return partial + conditional(100, arg);
     }
 })program";
 

--- a/main.cpp
+++ b/main.cpp
@@ -32,12 +32,14 @@ std::u32string program = UR"program(module hello_world
 {
     let foo = λ => 1 * 2 + 3 * 4;
 
+    let foobar = int;
+
     function bar()
     {
         return 5 + 6 * 7 + 8;
     }
 
-    function conditional(x : int, y : int)
+    function conditional(x : foobar, y : int)
     {
         if (x * y < 123)
         {

--- a/main.cpp
+++ b/main.cpp
@@ -55,7 +55,7 @@ std::u32string program = UR"program(module hello_world
     let entry = λ(arg : int)
     {
         let partial = foo() + bar();
-        return partial + conditional(100, arg);
+        return arg + conditional(100, partial);
     };
 })program";
 

--- a/main.cpp
+++ b/main.cpp
@@ -37,20 +37,23 @@ std::u32string program = UR"program(module hello_world
             return 0;
         }
 
-        if (n == 1)
+        else { if (n == 1)
         {
             return 1;
         }
 
-        if (n == 2)
+        else { if (n == 2)
         {
             return 1;
         }
 
-        return fibonacci(n - 1) + fibonacci(n - 2);
+        else
+        {
+            return fibonacci(n - 1) + fibonacci(n - 2);
+        }}}
     }
 
-    let entry = λ(arg : int)
+    let entry = λ(arg : int) -> int
     {
         let constant_foldable = fibonacci(7);
         let non_constant_foldable = fibonacci(arg);
@@ -90,8 +93,12 @@ int main() try
     auto ir = analyzed_ast.codegen_ir();
     reaver::vapor::codegen::result generated_code{ ir, reaver::vapor::codegen::make_cxx() };
 
-    reaver::logger::dlog() << "Codegen IR:";
-    reaver::logger::dlog() << ir;
+    // TODO: printing this actually needs a print_context
+    // to avoid endless repetitions of things
+    // and to fix the format
+    // actually this could be a generator... that'd make a lot of sense
+    // reaver::logger::dlog() << "Codegen IR:";
+    // reaver::logger::dlog() << ir;
 
     reaver::logger::dlog() << "Generated code:";
     reaver::logger::dlog() << generated_code;

--- a/main.cpp
+++ b/main.cpp
@@ -37,20 +37,17 @@ std::u32string program = UR"program(module hello_world
             return 0;
         }
 
-        else if (n == 1)
+        if (n == 1)
         {
             return 1;
         }
 
-        else if (n == 2)
+        if (n == 2)
         {
             return 1;
         }
 
-        else
-        {
-            return fibonacci(n - 1) + fibonacci(n - 2);
-        }
+        return fibonacci(n - 1) + fibonacci(n - 2);
     }
 
     let entry = λ(arg : int) -> int

--- a/main.cpp
+++ b/main.cpp
@@ -30,7 +30,7 @@
 
 std::u32string program = UR"program(module hello_world
 {
-    function fibonacci(n : int)
+    function fibonacci(n : int) -> int
     {
         if (n <= 0)
         {

--- a/main.cpp
+++ b/main.cpp
@@ -32,7 +32,7 @@ std::u32string program = UR"program(module hello_world
 {
     function fibonacci(n : int)
     {
-        if (n == 0)
+        if (n <= 0)
         {
             return 0;
         }

--- a/parser/declaration.cpp
+++ b/parser/declaration.cpp
@@ -34,11 +34,11 @@ reaver::vapor::parser::_v1::declaration reaver::vapor::parser::_v1::parse_declar
     {
         expect(ctx, lexer::token_type::colon);
 
-        ret.type_expression = parse_expression(ctx, true);
+        ret.type_expression = parse_expression(ctx, expression_special_modes::assignment);
     }
 
     expect(ctx, lexer::token_type::assign);
-    ret.rhs = parse_expression(ctx, true);
+    ret.rhs = parse_expression(ctx);
     ret.range = { start, ret.rhs.range.end() };
 
     return ret;
@@ -55,3 +55,4 @@ void reaver::vapor::parser::_v1::print(const reaver::vapor::parser::_v1::declara
     print(decl.rhs, os, indent + 4);
     os << in << "}\n";
 }
+

--- a/parser/expression.cpp
+++ b/parser/expression.cpp
@@ -32,7 +32,7 @@ namespace reaver
     template struct recursive_wrapper<vapor::parser::_v1::binary_expression>;
 }
 
-reaver::vapor::parser::_v1::expression reaver::vapor::parser::_v1::parse_expression(reaver::vapor::parser::_v1::context & ctx, bool special_assignment)
+reaver::vapor::parser::_v1::expression reaver::vapor::parser::_v1::parse_expression(reaver::vapor::parser::_v1::context & ctx, reaver::vapor::parser::_v1::expression_special_modes mode)
 {
     expression ret;
     auto type = peek(ctx)->type;
@@ -54,7 +54,7 @@ reaver::vapor::parser::_v1::expression reaver::vapor::parser::_v1::parse_express
 
     else if (peek(ctx, lexer::token_type::identifier))
     {
-        ret.expression_value = parse_postfix_expression(ctx);
+        ret.expression_value = parse_postfix_expression(ctx, mode);
     }
 
     else if (peek(ctx, lexer::token_type::import))
@@ -78,7 +78,7 @@ reaver::vapor::parser::_v1::expression reaver::vapor::parser::_v1::parse_express
     }
 
     type = peek(ctx)->type;
-    if (is_binary_operator(type) && !(special_assignment && type == lexer::token_type::assign))
+    if (is_binary_operator(type) && !(mode == expression_special_modes::assignment && type == lexer::token_type::assign))
     {
         auto p1 = precedence({ type, operator_type::binary });
         auto p2 = ctx.operator_stack.size() ? make_optional(precedence(ctx.operator_stack.back())) : none;

--- a/parser/function.cpp
+++ b/parser/function.cpp
@@ -38,18 +38,19 @@ reaver::vapor::parser::_v1::function reaver::vapor::parser::_v1::parse_function(
     }
     expect(ctx, lexer::token_type::round_bracket_close);
 
-    if (peek(ctx) && peek(ctx)->type == lexer::token_type::indirection)
+    if (peek(ctx, lexer::token_type::indirection))
     {
-        ret.return_type = parse_expression(ctx);
+        expect(ctx, lexer::token_type::indirection);
+        ret.return_type = parse_expression(ctx, expression_special_modes::brace);
     }
 
-    if (peek(ctx, lexer::token_type::curly_bracket_open))
+    if (peek(ctx, lexer::token_type::block_value))
     {
-        ret.body = parse_block(ctx);
+        ret.body = parse_single_statement_block(ctx);
     }
     else
     {
-        ret.body = parse_single_statement_block(ctx);
+        ret.body = parse_block(ctx);
     }
 
     ret.range = { start, ret.body->range.end() };
@@ -61,12 +62,17 @@ void reaver::vapor::parser::_v1::print(const reaver::vapor::parser::_v1::functio
 {
     auto in = std::string(indent, ' ');
 
-    assert(!f.return_type);
-
     os << in << "`function` at " << f.range << '\n';
     os << in << "{\n";
     os << std::string(indent + 4, ' ') << f.name << '\n';
     fmap(f.arguments, [&](auto && arguments){ print(arguments, os, indent + 4); return unit{}; });
+    fmap(f.return_type, [&](auto && ret_type) {
+        os << in << "return type:\n";
+        os << in << "{\n";
+        print(ret_type, os, indent + 4);
+        os << in << "}\n";
+        return unit{};
+    });
     print(*f.body, os, indent + 4);
     os << in << "}\n";
 }

--- a/parser/function.cpp
+++ b/parser/function.cpp
@@ -61,11 +61,12 @@ void reaver::vapor::parser::_v1::print(const reaver::vapor::parser::_v1::functio
 {
     auto in = std::string(indent, ' ');
 
-    assert(!f.arguments && !f.return_type);
+    assert(!f.return_type);
 
     os << in << "`function` at " << f.range << '\n';
     os << in << "{\n";
     os << std::string(indent + 4, ' ') << f.name << '\n';
+    fmap(f.arguments, [&](auto && arguments){ print(arguments, os, indent + 4); return unit{}; });
     print(*f.body, os, indent + 4);
     os << in << "}\n";
 }

--- a/parser/lambda_expression.cpp
+++ b/parser/lambda_expression.cpp
@@ -68,9 +68,10 @@ void reaver::vapor::parser::_v1::print(const reaver::vapor::parser::_v1::lambda_
 
     os << in << "`lambda-expression` at " << expr.range << '\n';
 
-    assert(!expr.captures && !expr.arguments);
+    assert(!expr.captures);
 
     os << in << "{\n";
+    fmap(expr.arguments, [&](auto && arguments){ print(arguments, os, indent + 4); return unit{}; });
     print(expr.body, os, indent + 4);
     os << in << "}\n";
 }

--- a/parser/lambda_expression.cpp
+++ b/parser/lambda_expression.cpp
@@ -48,6 +48,12 @@ reaver::vapor::parser::_v1::lambda_expression reaver::vapor::parser::_v1::parse_
         expect(ctx, lexer::token_type::round_bracket_close);
     }
 
+    if (peek(ctx, lexer::token_type::indirection))
+    {
+        expect(ctx, lexer::token_type::indirection);
+        ret.return_type = parse_expression(ctx, expression_special_modes::brace);
+    }
+
     if (peek(ctx, lexer::token_type::block_value))
     {
         ret.body = parse_single_statement_block(ctx);

--- a/parser/postfix_expression.cpp
+++ b/parser/postfix_expression.cpp
@@ -73,12 +73,16 @@ reaver::vapor::parser::_v1::postfix_expression reaver::vapor::parser::_v1::parse
     {
         if (!peek(ctx, closing(*ret.bracket_type)))
         {
+            auto old_stack = std::move(ctx.operator_stack);
+
             ret.arguments.push_back(parse_expression(ctx));
             while (peek(ctx, lexer::token_type::comma))
             {
                 expect(ctx, lexer::token_type::comma);
                 ret.arguments.push_back(parse_expression(ctx));
             }
+
+            ctx.operator_stack = std::move(old_stack);
         }
         end = expect(ctx, closing(*ret.bracket_type)).range.end();
     }

--- a/parser/postfix_expression.cpp
+++ b/parser/postfix_expression.cpp
@@ -32,7 +32,6 @@ reaver::vapor::parser::_v1::postfix_expression reaver::vapor::parser::_v1::parse
         using namespace lexer;
         switch (type)
         {
-            case token_type::angle_bracket_open: return token_type::angle_bracket_close;
             case token_type::round_bracket_open: return token_type::round_bracket_close;
             case token_type::square_bracket_open: return token_type::square_bracket_close;
             case token_type::curly_bracket_open: return token_type::curly_bracket_close;
@@ -59,8 +58,7 @@ reaver::vapor::parser::_v1::postfix_expression reaver::vapor::parser::_v1::parse
         end = range.end();
     }
 
-    for (auto && type : { lexer::token_type::round_bracket_open, lexer::token_type::square_bracket_open, lexer::token_type::curly_bracket_open,
-        lexer::token_type::angle_bracket_open })
+    for (auto && type : { lexer::token_type::round_bracket_open, lexer::token_type::square_bracket_open, lexer::token_type::curly_bracket_open })
     {
         if (peek(ctx, type))
         {

--- a/parser/postfix_expression.cpp
+++ b/parser/postfix_expression.cpp
@@ -25,7 +25,7 @@
 #include "vapor/parser/expression_list.h"
 #include "vapor/parser/lambda_expression.h"
 
-reaver::vapor::parser::_v1::postfix_expression reaver::vapor::parser::_v1::parse_postfix_expression(reaver::vapor::parser::context & ctx)
+reaver::vapor::parser::_v1::postfix_expression reaver::vapor::parser::_v1::parse_postfix_expression(reaver::vapor::parser::context & ctx, reaver::vapor::parser::_v1::expression_special_modes mode)
 {
     auto closing = [](lexer::token_type type)
     {
@@ -60,6 +60,11 @@ reaver::vapor::parser::_v1::postfix_expression reaver::vapor::parser::_v1::parse
 
     for (auto && type : { lexer::token_type::round_bracket_open, lexer::token_type::square_bracket_open, lexer::token_type::curly_bracket_open })
     {
+        if (type == lexer::token_type::curly_bracket_open && mode == expression_special_modes::brace)
+        {
+            continue;
+        }
+
         if (peek(ctx, type))
         {
             ret.bracket_type = type;

--- a/tests/parser/function.cpp
+++ b/tests/parser/function.cpp
@@ -98,6 +98,136 @@ MAYFLY_ADD_TESTCASE("no arguments, deduced type, regular body", test(
     &parse_function
 ));
 
+MAYFLY_ADD_TESTCASE("one argument, deduced type, simple body", test(
+    UR"(function foo(x : int) => constant;)",
+    function{
+        { 0, 33 },
+        { lexer::token_type::identifier, UR"(foo)", { 9, 12 } },
+        reaver::make_optional(argument_list{
+            { 13, 20 },
+            {
+                argument{
+                    { 13, 20 },
+                    { lexer::token_type::identifier, UR"(x)", { 13, 14 } },
+                    {
+                        { 17, 20 },
+                        postfix_expression{
+                            { 17, 20 },
+                            id_expression{
+                                { 17, 20 },
+                                {
+                                    { lexer::token_type::identifier, UR"(int)", { 17, 20 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            }
+        }),
+        {},
+        block{
+            { 22, 33 },
+            {},
+            { expression_list{
+                { 25, 33 },
+                {
+                    {
+                        { 25, 33 },
+                        postfix_expression{
+                            { 25, 33 },
+                            { id_expression{
+                                { 25, 33 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 25, 33 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_function
+));
+
+MAYFLY_ADD_TESTCASE("two arguments, deduced type, simple body", test(
+    UR"(function foo(x : int, y : bool) => constant;)",
+    function{
+        { 0, 43 },
+        { lexer::token_type::identifier, UR"(foo)", { 9, 12 } },
+        reaver::make_optional(argument_list{
+            { 13, 30 },
+            {
+                argument{
+                    { 13, 20 },
+                    { lexer::token_type::identifier, UR"(x)", { 13, 14 } },
+                    {
+                        { 17, 20 },
+                        postfix_expression{
+                            { 17, 20 },
+                            id_expression{
+                                { 17, 20 },
+                                {
+                                    { lexer::token_type::identifier, UR"(int)", { 17, 20 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                },
+                argument{
+                    { 22, 30 },
+                    { lexer::token_type::identifier, UR"(y)", { 22, 23 } },
+                    {
+                        { 26, 30 },
+                        postfix_expression{
+                            { 26, 30 },
+                            id_expression{
+                                { 26, 30 },
+                                {
+                                    { lexer::token_type::identifier, UR"(bool)", { 26, 30 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            }
+        }),
+        {},
+        block{
+            { 32, 43 },
+            {},
+            { expression_list{
+                { 35, 43 },
+                {
+                    {
+                        { 35, 43 },
+                        postfix_expression{
+                            { 35, 43 },
+                            { id_expression{
+                                { 35, 43 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 35, 43 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_function
+));
+
 MAYFLY_END_SUITE;
 MAYFLY_END_SUITE;
 

--- a/tests/parser/function.cpp
+++ b/tests/parser/function.cpp
@@ -64,6 +64,53 @@ MAYFLY_ADD_TESTCASE("no arguments, deduced type, simple body", test(
     &parse_function
 ));
 
+MAYFLY_ADD_TESTCASE("no arguments, explicit type, simple body", test(
+    UR"(function foo() -> int => constant;)",
+    function{
+        { 0, 33 },
+        { lexer::token_type::identifier, UR"(foo)", { 9, 12 } },
+        {},
+        reaver::make_optional(expression{
+            { 18, 21 },
+            postfix_expression{
+                { 18, 21 },
+                { id_expression {
+                    { 18, 21 },
+                    {
+                        { lexer::token_type::identifier, UR"(int)", { 18, 21 } }
+                    },
+                } },
+                {},
+                {}
+            }
+        }),
+        block{
+            { 22, 33 },
+            {},
+            { expression_list{
+                { 25, 33 },
+                {
+                    {
+                        { 25, 33 },
+                        postfix_expression{
+                            { 25, 33 },
+                            { id_expression{
+                                { 25, 33 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 25, 33 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_function
+));
+
 MAYFLY_ADD_TESTCASE("no arguments, deduced type, regular body", test(
     UR"(function foo() { => constant })",
     function{
@@ -85,6 +132,53 @@ MAYFLY_ADD_TESTCASE("no arguments, deduced type, regular body", test(
                                 { 20, 28 },
                                 {
                                     { lexer::token_type::identifier, UR"(constant)", { 20, 28 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_function
+));
+
+MAYFLY_ADD_TESTCASE("no arguments, explicit type, regular body", test(
+    UR"(function foo() -> int { => constant })",
+    function{
+        { 0, 37 },
+        { lexer::token_type::identifier, UR"(foo)", { 9, 12 } },
+        {},
+        reaver::make_optional(expression{
+            { 18, 21 },
+            postfix_expression{
+                { 18, 21 },
+                { id_expression {
+                    { 18, 21 },
+                    {
+                        { lexer::token_type::identifier, UR"(int)", { 18, 21 } }
+                    },
+                } },
+                {},
+                {}
+            }
+        }),
+        block{
+            { 22, 37 },
+            {},
+            { expression_list{
+                { 27, 35 },
+                {
+                    {
+                        { 27, 35 },
+                        postfix_expression{
+                            { 27, 35 },
+                            { id_expression{
+                                { 27, 35 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 27, 35 } }
                                 }
                             } },
                             {},
@@ -141,6 +235,75 @@ MAYFLY_ADD_TESTCASE("one argument, deduced type, simple body", test(
                                 { 25, 33 },
                                 {
                                     { lexer::token_type::identifier, UR"(constant)", { 25, 33 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_function
+));
+
+MAYFLY_ADD_TESTCASE("one argument, explicit type, simple body", test(
+    UR"(function foo(x : int) -> int => constant;)",
+    function{
+        { 0, 40 },
+        { lexer::token_type::identifier, UR"(foo)", { 9, 12 } },
+        reaver::make_optional(argument_list{
+            { 13, 20 },
+            {
+                argument{
+                    { 13, 20 },
+                    { lexer::token_type::identifier, UR"(x)", { 13, 14 } },
+                    {
+                        { 17, 20 },
+                        postfix_expression{
+                            { 17, 20 },
+                            id_expression{
+                                { 17, 20 },
+                                {
+                                    { lexer::token_type::identifier, UR"(int)", { 17, 20 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            }
+        }),
+        reaver::make_optional(expression{
+            { 25, 28 },
+            postfix_expression{
+                { 25, 28 },
+                { id_expression {
+                    { 25, 28 },
+                    {
+                        { lexer::token_type::identifier, UR"(int)", { 25, 28 } }
+                    },
+                } },
+                {},
+                {}
+            }
+        }),
+        block{
+            { 29, 40 },
+            {},
+            { expression_list{
+                { 32, 40 },
+                {
+                    {
+                        { 32, 40 },
+                        postfix_expression{
+                            { 32, 40 },
+                            { id_expression{
+                                { 32, 40 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 32, 40 } }
                                 }
                             } },
                             {},
@@ -215,6 +378,93 @@ MAYFLY_ADD_TESTCASE("two arguments, deduced type, simple body", test(
                                 { 35, 43 },
                                 {
                                     { lexer::token_type::identifier, UR"(constant)", { 35, 43 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_function
+));
+
+MAYFLY_ADD_TESTCASE("two arguments, explicit type, simple body", test(
+    UR"(function foo(x : int, y : bool) -> int => constant;)",
+    function{
+        { 0, 50 },
+        { lexer::token_type::identifier, UR"(foo)", { 9, 12 } },
+        reaver::make_optional(argument_list{
+            { 13, 30 },
+            {
+                argument{
+                    { 13, 20 },
+                    { lexer::token_type::identifier, UR"(x)", { 13, 14 } },
+                    {
+                        { 17, 20 },
+                        postfix_expression{
+                            { 17, 20 },
+                            id_expression{
+                                { 17, 20 },
+                                {
+                                    { lexer::token_type::identifier, UR"(int)", { 17, 20 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                },
+                argument{
+                    { 22, 30 },
+                    { lexer::token_type::identifier, UR"(y)", { 22, 23 } },
+                    {
+                        { 26, 30 },
+                        postfix_expression{
+                            { 26, 30 },
+                            id_expression{
+                                { 26, 30 },
+                                {
+                                    { lexer::token_type::identifier, UR"(bool)", { 26, 30 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            }
+        }),
+        reaver::make_optional(expression{
+            { 35, 38 },
+            postfix_expression{
+                { 35, 38 },
+                { id_expression {
+                    { 35, 38 },
+                    {
+                        { lexer::token_type::identifier, UR"(int)", { 35, 38 } }
+                    },
+                } },
+                {},
+                {}
+            }
+        }),
+        block{
+            { 39, 50 },
+            {},
+            { expression_list{
+                { 42, 50 },
+                {
+                    {
+                        { 42, 50 },
+                        postfix_expression{
+                            { 42, 50 },
+                            { id_expression{
+                                { 42, 50 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 42, 50 } }
                                 }
                             } },
                             {},

--- a/tests/parser/lambda_expression.cpp
+++ b/tests/parser/lambda_expression.cpp
@@ -64,6 +64,53 @@ MAYFLY_ADD_TESTCASE("no arguments, deduced type, simple body", test(
     &parse_lambda_expression
 ));
 
+MAYFLY_ADD_TESTCASE("no arguments, explicit type, simple body", test(
+    UR"(λ -> int => constant;)",
+    lambda_expression{
+        { 0, 20 },
+        {},
+        {},
+        reaver::make_optional(expression{
+            { 5, 8 },
+            postfix_expression{
+                { 5, 8 },
+                { id_expression {
+                    { 5, 8 },
+                    {
+                        { lexer::token_type::identifier, UR"(int)", { 5, 8 } }
+                    },
+                } },
+                {},
+                {}
+            }
+        }),
+        block{
+            { 9, 20 },
+            {},
+            { expression_list{
+                { 12, 20 },
+                {
+                    {
+                        { 12, 20 },
+                        postfix_expression{
+                            { 12, 20 },
+                            { id_expression{
+                                { 12, 20 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 12, 20 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_lambda_expression
+));
+
 MAYFLY_ADD_TESTCASE("no arguments, deduced type, regular body", test(
     UR"(λ { => constant })",
     lambda_expression{
@@ -85,6 +132,53 @@ MAYFLY_ADD_TESTCASE("no arguments, deduced type, regular body", test(
                                 { 7, 15 },
                                 {
                                     { lexer::token_type::identifier, UR"(constant)", { 7, 15 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_lambda_expression
+));
+
+MAYFLY_ADD_TESTCASE("no arguments, explicit type, regular body", test(
+    UR"(λ -> int { => constant })",
+    lambda_expression{
+        { 0, 24 },
+        {},
+        {},
+        reaver::make_optional(expression{
+            { 5, 8 },
+            postfix_expression{
+                { 5, 8 },
+                { id_expression {
+                    { 5, 8 },
+                    {
+                        { lexer::token_type::identifier, UR"(int)", { 5, 8 } }
+                    },
+                } },
+                {},
+                {}
+            }
+        }),
+        block{
+            { 9, 24 },
+            {},
+            { expression_list{
+                { 14, 22 },
+                {
+                    {
+                        { 14, 22 },
+                        postfix_expression{
+                            { 14, 22 },
+                            { id_expression{
+                                { 14, 22 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 14, 22 } }
                                 }
                             } },
                             {},
@@ -141,6 +235,75 @@ MAYFLY_ADD_TESTCASE("one argument, deduced type, simple body", test(
                                 { 14, 22 },
                                 {
                                     { lexer::token_type::identifier, UR"(constant)", { 14, 22 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_lambda_expression
+));
+
+MAYFLY_ADD_TESTCASE("one argument, explicit type, simple body", test(
+    UR"(λ(x : int) -> int => constant;)",
+    lambda_expression{
+        { 0, 29 },
+        {},
+        reaver::make_optional(argument_list{
+            { 2, 9 },
+            {
+                argument{
+                    { 2, 9 },
+                    { lexer::token_type::identifier, UR"(x)", { 2, 3 } },
+                    {
+                        { 6, 9 },
+                        postfix_expression{
+                            { 6, 9 },
+                            id_expression{
+                                { 6, 9 },
+                                {
+                                    { lexer::token_type::identifier, UR"(int)", { 6, 9 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            }
+        }),
+        reaver::make_optional(expression{
+            { 14, 17 },
+            postfix_expression{
+                { 14, 17 },
+                { id_expression {
+                    { 14, 17 },
+                    {
+                        { lexer::token_type::identifier, UR"(int)", { 14, 17 } }
+                    },
+                } },
+                {},
+                {}
+            }
+        }),
+        block{
+            { 18, 29 },
+            {},
+            { expression_list{
+                { 21, 29 },
+                {
+                    {
+                        { 21, 29 },
+                        postfix_expression{
+                            { 21, 29 },
+                            { id_expression{
+                                { 21, 29 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 21, 29 } }
                                 }
                             } },
                             {},
@@ -215,6 +378,93 @@ MAYFLY_ADD_TESTCASE("two arguments, deduced type, simple body", test(
                                 { 24, 32 },
                                 {
                                     { lexer::token_type::identifier, UR"(constant)", { 24, 32 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_lambda_expression
+));
+
+MAYFLY_ADD_TESTCASE("two arguments, explicit type, simple body", test(
+    UR"(λ(x : int, y : bool) -> int => constant;)",
+    lambda_expression{
+        { 0, 39 },
+        {},
+        reaver::make_optional(argument_list{
+            { 2, 19 },
+            {
+                argument{
+                    { 2, 9 },
+                    { lexer::token_type::identifier, UR"(x)", { 2, 3 } },
+                    {
+                        { 6, 9 },
+                        postfix_expression{
+                            { 6, 9 },
+                            id_expression{
+                                { 6, 9 },
+                                {
+                                    { lexer::token_type::identifier, UR"(int)", { 6, 9 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                },
+                argument{
+                    { 11, 19 },
+                    { lexer::token_type::identifier, UR"(y)", { 11, 12 } },
+                    {
+                        { 15, 19 },
+                        postfix_expression{
+                            { 15, 19 },
+                            id_expression{
+                                { 15, 19 },
+                                {
+                                    { lexer::token_type::identifier, UR"(bool)", { 15, 19 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            }
+        }),
+        reaver::make_optional(expression{
+            { 24, 27 },
+            postfix_expression{
+                { 24, 27 },
+                { id_expression {
+                    { 24, 27 },
+                    {
+                        { lexer::token_type::identifier, UR"(int)", { 24, 27 } }
+                    },
+                } },
+                {},
+                {}
+            }
+        }),
+        block{
+            { 28, 39 },
+            {},
+            { expression_list{
+                { 31, 39 },
+                {
+                    {
+                        { 31, 39 },
+                        postfix_expression{
+                            { 31, 39 },
+                            { id_expression{
+                                { 31, 39 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 31, 39 } }
                                 }
                             } },
                             {},

--- a/tests/parser/lambda_expression.cpp
+++ b/tests/parser/lambda_expression.cpp
@@ -96,6 +96,134 @@ MAYFLY_ADD_TESTCASE("no arguments, deduced type, regular body", test(
     &parse_lambda_expression
 ));
 
+MAYFLY_ADD_TESTCASE("one argument, deduced type, simple body", test(
+    UR"(λ(x : int) => constant;)",
+    lambda_expression{
+        { 0, 22 },
+        {},
+        reaver::make_optional(argument_list{
+            { 2, 9 },
+            {
+                argument{
+                    { 2, 9 },
+                    { lexer::token_type::identifier, UR"(x)", { 2, 3 } },
+                    {
+                        { 6, 9 },
+                        postfix_expression{
+                            { 6, 9 },
+                            id_expression{
+                                { 6, 9 },
+                                {
+                                    { lexer::token_type::identifier, UR"(int)", { 6, 9 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            }
+        }),
+        block{
+            { 11, 22 },
+            {},
+            { expression_list{
+                { 14, 22 },
+                {
+                    {
+                        { 14, 22 },
+                        postfix_expression{
+                            { 14, 22 },
+                            { id_expression{
+                                { 14, 22 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 14, 22 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_lambda_expression
+));
+
+MAYFLY_ADD_TESTCASE("two arguments, deduced type, simple body", test(
+    UR"(λ(x : int, y : bool) => constant;)",
+    lambda_expression{
+        { 0, 32 },
+        {},
+        reaver::make_optional(argument_list{
+            { 2, 19 },
+            {
+                argument{
+                    { 2, 9 },
+                    { lexer::token_type::identifier, UR"(x)", { 2, 3 } },
+                    {
+                        { 6, 9 },
+                        postfix_expression{
+                            { 6, 9 },
+                            id_expression{
+                                { 6, 9 },
+                                {
+                                    { lexer::token_type::identifier, UR"(int)", { 6, 9 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                },
+                argument{
+                    { 11, 19 },
+                    { lexer::token_type::identifier, UR"(y)", { 11, 12 } },
+                    {
+                        { 15, 19 },
+                        postfix_expression{
+                            { 15, 19 },
+                            id_expression{
+                                { 15, 19 },
+                                {
+                                    { lexer::token_type::identifier, UR"(bool)", { 15, 19 } }
+                                }
+                            },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            }
+        }),
+        block{
+            { 21, 32 },
+            {},
+            { expression_list{
+                { 24, 32 },
+                {
+                    {
+                        { 24, 32 },
+                        postfix_expression{
+                            { 24, 32 },
+                            { id_expression{
+                                { 24, 32 },
+                                {
+                                    { lexer::token_type::identifier, UR"(constant)", { 24, 32 } }
+                                }
+                            } },
+                            {},
+                            {}
+                        }
+                    }
+                }
+            } }
+        }
+    },
+    &parse_lambda_expression
+));
+
 MAYFLY_END_SUITE;
 MAYFLY_END_SUITE;
 

--- a/tests/parser/lambda_expression.cpp
+++ b/tests/parser/lambda_expression.cpp
@@ -36,6 +36,7 @@ MAYFLY_ADD_TESTCASE("no arguments, deduced type, simple body", test(
         { 0, 13 },
         {},
         {},
+        {},
         block{
             { 2, 13 },
             {},
@@ -67,6 +68,7 @@ MAYFLY_ADD_TESTCASE("no arguments, deduced type, regular body", test(
     UR"(λ { => constant })",
     lambda_expression{
         { 0, 17 },
+        {},
         {},
         {},
         block{
@@ -124,6 +126,7 @@ MAYFLY_ADD_TESTCASE("one argument, deduced type, simple body", test(
                 }
             }
         }),
+        {},
         block{
             { 11, 22 },
             {},
@@ -197,6 +200,7 @@ MAYFLY_ADD_TESTCASE("two arguments, deduced type, simple body", test(
                 }
             }
         }),
+        {},
         block{
             { 21, 32 },
             {},

--- a/tests/parser/postfix_expression.cpp
+++ b/tests/parser/postfix_expression.cpp
@@ -42,7 +42,9 @@ MAYFLY_ADD_TESTCASE("basic postfix-expression", test(UR"(foo;)",
         {},
         {}
     },
-    &parse_postfix_expression
+    [](auto && ctx) {
+        return parse_postfix_expression(ctx);
+    }
 ));
 
 MAYFLY_ADD_TESTCASE("argumentless", test(UR"(foo();)",
@@ -57,7 +59,9 @@ MAYFLY_ADD_TESTCASE("argumentless", test(UR"(foo();)",
         lexer::token_type::round_bracket_open,
         {}
     },
-    &parse_postfix_expression
+    [](auto && ctx) {
+        return parse_postfix_expression(ctx);
+    }
 ));
 
 MAYFLY_ADD_TESTCASE("one argument", test(UR"(foo[1];)",
@@ -81,7 +85,9 @@ MAYFLY_ADD_TESTCASE("one argument", test(UR"(foo[1];)",
             }
         }
     },
-    &parse_postfix_expression
+    [](auto && ctx) {
+        return parse_postfix_expression(ctx);
+    }
 ));
 
 MAYFLY_ADD_TESTCASE("more arguments", test(UR"(foo{ a, b, c };)",
@@ -130,7 +136,9 @@ MAYFLY_ADD_TESTCASE("more arguments", test(UR"(foo{ a, b, c };)",
             }
         }
     },
-    &parse_postfix_expression
+    [](auto && ctx) {
+        return parse_postfix_expression(ctx);
+    }
 ));
 
 MAYFLY_END_SUITE;


### PR DESCRIPTION
Since this wants to also be able to do `fibonacci` as the ultimate example, and since that requires recursion, and since that kind of requires specifying function return types ATM, this also includes support for specifying return types for functions and lambdas.
